### PR TITLE
Rename and add numbers to filenames

### DIFF
--- a/dags/dag_kantinedata/dag_kantinedata.py
+++ b/dags/dag_kantinedata/dag_kantinedata.py
@@ -13,10 +13,14 @@ with DAG(
     start_date=datetime(year=2026, month=1, day=16, tz=timezone("Europe/Copenhagen")),
     schedule='@daily',
     catchup=False,
+    max_active_runs=1,
+    max_active_tasks=1,
     default_args=dag_args,
     description="Extract Kantinedata from email attachments and load into SFTP",
     tags=["kantinedata", "email", "sftp"],
 ) as dag:
     run_kantinedata = PythonOperator(
-        task_id="process_kantinedata_task", python_callable=process_kantinedata
+        task_id="process_kantinedata_task",
+        python_callable=process_kantinedata,
+        max_active_tis_per_dag=1,
     )

--- a/dags/dag_kantinedata/process_kantinedata.py
+++ b/dags/dag_kantinedata/process_kantinedata.py
@@ -1,10 +1,21 @@
 import logging
 import io
 import errno
+from typing import TYPE_CHECKING
 
-from airflow.providers.sftp.hooks.sftp import SFTPHook
-from airflow.models import Variable
+try:
+    from airflow.providers.sftp.hooks.sftp import SFTPHook
+    from airflow.models import Variable
+except ModuleNotFoundError as e:
+    if e.name and (e.name == "airflow" or e.name.startswith("airflow.")):  # For pytest environment without Airflow installed
+        SFTPHook = None
+        Variable = None
+    else:
+        raise
 from dag_kantinedata.mail_utils import imap_get_emails_with_uids, extract_attachments, decode_mime_word
+
+if TYPE_CHECKING:
+    from paramiko import SFTPClient
 
 logger = logging.getLogger(__name__)
 
@@ -13,7 +24,7 @@ _KANTINEDATA_FILE_COUNTER_VAR_KEY = "kantinedata_file_counter"
 _KANTINEDATA_FILE_COUNTER_MAX = 10
 
 
-def _sftp_path_exists(sftp_client: SFTPHook, remote_path: str) -> bool:
+def _sftp_path_exists(sftp_client: "SFTPClient", remote_path: str) -> bool:
     """
     Check if a remote path exists on the SFTP server.
 
@@ -32,7 +43,7 @@ def _sftp_path_exists(sftp_client: SFTPHook, remote_path: str) -> bool:
         raise
 
 
-def _allocate_next_filename(sftp_client: SFTPHook) -> str:
+def _allocate_next_filename(sftp_client: "SFTPClient") -> str:
     """Allocate the next Kantinedata filename (1..10, wrapping).
 
     Uses an Airflow Variable as the source of truth and increments it (wrapping after 10).

--- a/dags/dag_kantinedata/process_kantinedata.py
+++ b/dags/dag_kantinedata/process_kantinedata.py
@@ -1,13 +1,90 @@
 import logging
 import io
+import errno
 
 from airflow.providers.sftp.hooks.sftp import SFTPHook
+try:
+    from airflow.models import Variable
+except Exception:
+    Variable = None
 from dag_kantinedata.mail_utils import imap_get_emails_with_uids, extract_attachments, decode_mime_word
 
 logger = logging.getLogger(__name__)
 
 
+_KANTINEDATA_FILE_COUNTER_VAR_KEY = "kantinedata_file_counter"
+
+
+def _safe_int(value: object, default: int = 0) -> int:
+    """
+    Safely convert a value to an integer, returning a default if conversion fails.
+
+    :param value: The value to convert (e.g. from Airflow Variable).
+    :param default: The default integer to return if conversion fails.
+    :return: The converted integer or the default.
+    """
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return default
+
+
+def _sftp_path_exists(sftp_client: SFTPHook, remote_path: str) -> bool:
+    """
+    Check if a remote path exists on the SFTP server.
+
+    :param sftp_client: An active SFTP client connection.
+    :param remote_path: The remote path to check (e.g. "/EksportedeOrdrer_1.xml").
+    :return: True if the path exists, False otherwise.
+    """
+    try:
+        sftp_client.stat(remote_path)
+        return True
+    except FileNotFoundError:
+        return False
+    except OSError as e:
+        if getattr(e, "errno", None) in {errno.ENOENT, 2}:
+            return False
+        raise
+
+
+def _allocate_next_filename(sftp_client: SFTPHook) -> str:
+    """Allocate the next monotonic Kantinedata filename.
+
+    Uses an Airflow Variable as the source of truth and increments it.
+    Also checks the SFTP destination for collisions (e.g. if the variable was reset).
+
+    :param sftp_client: An active SFTP client connection.
+    :return: The allocated filename (e.g. "EksportedeOrdrer_1.xml").
+    """
+    if Variable is None:
+        raise RuntimeError(
+            "Airflow Variable is not available."
+        )
+
+    current_raw = Variable.get(_KANTINEDATA_FILE_COUNTER_VAR_KEY, default_var="0")
+    next_number = max(1, _safe_int(current_raw, default=0) + 1)
+
+    remote_path = f"/EksportedeOrdrer_{next_number}.xml"
+    while _sftp_path_exists(sftp_client, remote_path):
+        next_number += 1
+        remote_path = f"/EksportedeOrdrer_{next_number}.xml"
+
+    Variable.set(_KANTINEDATA_FILE_COUNTER_VAR_KEY, str(next_number))
+    return remote_path.lstrip("/")
+
+
 def process_kantinedata():
+    """
+    Main function to process Kantinedata emails from the INBOX.
+    - Fetches flagged emails (from previous failed runs) and unseen emails (new).
+    - Flags unseen emails while processing.
+    - Extracts attachments and uploads XML files to SFTP.
+    - Unflags successfully processed emails, and logs any failures for retry.
+    - Uses Airflow Variable to maintain a monotonic counter for filenames, with collision checks against SFTP.
+    - Logs detailed information about processing steps and errors.
+    - Raises an exception if any email fails to process, which triggers retries.
+    """
     # Fetch emails from the kantinedata INBOX
     try:
         # First, fetch flagged mails that have not finished processing (from failed runs)
@@ -91,8 +168,9 @@ def process_kantinedata():
                 if attachment.get("content_type") in ["application/xml", "text/xml"]:
                     if sftp_hook is None:
                         sftp_hook = SFTPHook("kantinedata_sftp")
-                    remote_path = f"/{attachment['filename']}"
                     with sftp_hook.get_conn() as sftp_client:
+                        filename = _allocate_next_filename(sftp_client)
+                        remote_path = f"/{filename}"
                         sftp_client.putfo(io.BytesIO(attachment["content_bytes"]), remote_path)
                     logger.info("Uploaded attachment to SFTP: %s", remote_path)
 

--- a/dags/dag_kantinedata/process_kantinedata.py
+++ b/dags/dag_kantinedata/process_kantinedata.py
@@ -13,6 +13,7 @@ logger = logging.getLogger(__name__)
 
 
 _KANTINEDATA_FILE_COUNTER_VAR_KEY = "kantinedata_file_counter"
+_KANTINEDATA_FILE_COUNTER_MAX = 10
 
 
 def _safe_int(value: object, default: int = 0) -> int:
@@ -49,9 +50,9 @@ def _sftp_path_exists(sftp_client: SFTPHook, remote_path: str) -> bool:
 
 
 def _allocate_next_filename(sftp_client: SFTPHook) -> str:
-    """Allocate the next monotonic Kantinedata filename.
+    """Allocate the next Kantinedata filename (1..10, wrapping).
 
-    Uses an Airflow Variable as the source of truth and increments it.
+    Uses an Airflow Variable as the source of truth and increments it (wrapping after 10).
     Also checks the SFTP destination for collisions (e.g. if the variable was reset).
 
     :param sftp_client: An active SFTP client connection.
@@ -63,15 +64,19 @@ def _allocate_next_filename(sftp_client: SFTPHook) -> str:
         )
 
     current_raw = Variable.get(_KANTINEDATA_FILE_COUNTER_VAR_KEY, default_var="0")
-    next_number = max(1, _safe_int(current_raw, default=0) + 1)
+    current_number = _safe_int(current_raw, default=0)
 
-    remote_path = f"/EksportedeOrdrer_{next_number}.xml"
-    while _sftp_path_exists(sftp_client, remote_path):
-        next_number += 1
-        remote_path = f"/EksportedeOrdrer_{next_number}.xml"
+    candidate = (current_number % _KANTINEDATA_FILE_COUNTER_MAX) + 1
+    for _ in range(_KANTINEDATA_FILE_COUNTER_MAX):
+        remote_path = f"/EksportedeOrdrer_{candidate}.xml"
+        if not _sftp_path_exists(sftp_client, remote_path):
+            Variable.set(_KANTINEDATA_FILE_COUNTER_VAR_KEY, str(candidate))
+            return remote_path.lstrip("/")
+        candidate = (candidate % _KANTINEDATA_FILE_COUNTER_MAX) + 1
 
-    Variable.set(_KANTINEDATA_FILE_COUNTER_VAR_KEY, str(next_number))
-    return remote_path.lstrip("/")
+    raise RuntimeError(
+        f"No available Kantinedata filename slots on SFTP (1-{_KANTINEDATA_FILE_COUNTER_MAX})."
+    )
 
 
 def process_kantinedata():

--- a/dags/dag_kantinedata/process_kantinedata.py
+++ b/dags/dag_kantinedata/process_kantinedata.py
@@ -3,10 +3,7 @@ import io
 import errno
 
 from airflow.providers.sftp.hooks.sftp import SFTPHook
-try:
-    from airflow.models import Variable
-except Exception:
-    Variable = None
+from airflow.models import Variable
 from dag_kantinedata.mail_utils import imap_get_emails_with_uids, extract_attachments, decode_mime_word
 
 logger = logging.getLogger(__name__)
@@ -14,20 +11,6 @@ logger = logging.getLogger(__name__)
 
 _KANTINEDATA_FILE_COUNTER_VAR_KEY = "kantinedata_file_counter"
 _KANTINEDATA_FILE_COUNTER_MAX = 10
-
-
-def _safe_int(value: object, default: int = 0) -> int:
-    """
-    Safely convert a value to an integer, returning a default if conversion fails.
-
-    :param value: The value to convert (e.g. from Airflow Variable).
-    :param default: The default integer to return if conversion fails.
-    :return: The converted integer or the default.
-    """
-    try:
-        return int(value)
-    except (TypeError, ValueError):
-        return default
 
 
 def _sftp_path_exists(sftp_client: SFTPHook, remote_path: str) -> bool:
@@ -64,7 +47,15 @@ def _allocate_next_filename(sftp_client: SFTPHook) -> str:
         )
 
     current_raw = Variable.get(_KANTINEDATA_FILE_COUNTER_VAR_KEY, default_var="0")
-    current_number = _safe_int(current_raw, default=0)
+    current_number = 0
+    try:
+        current_number = int(current_raw)
+    except (TypeError, ValueError):
+        logger.warning(
+            "Invalid value for Airflow Variable '%s': %s. Defaulting to 0.",
+            _KANTINEDATA_FILE_COUNTER_VAR_KEY,
+            current_raw,
+        )
 
     candidate = (current_number % _KANTINEDATA_FILE_COUNTER_MAX) + 1
     for _ in range(_KANTINEDATA_FILE_COUNTER_MAX):
@@ -86,7 +77,7 @@ def process_kantinedata():
     - Flags unseen emails while processing.
     - Extracts attachments and uploads XML files to SFTP.
     - Unflags successfully processed emails, and logs any failures for retry.
-    - Uses Airflow Variable to maintain a monotonic counter for filenames, with collision checks against SFTP.
+    - Uses Airflow Variable to maintain a counter for filenames, with collision checks against SFTP.
     - Logs detailed information about processing steps and errors.
     - Raises an exception if any email fails to process, which triggers retries.
     """

--- a/tests/dags/dag_kantinedata/test_process_kantinedata.py
+++ b/tests/dags/dag_kantinedata/test_process_kantinedata.py
@@ -22,14 +22,25 @@ class PutCall:
 
 
 class FakeSFTPClient:
-    def __init__(self, *, put_impl: Callable[[bytes, str], None] | None = None):
+    def __init__(
+        self,
+        *,
+        put_impl: Callable[[bytes, str], None] | None = None,
+        existing_paths: set[str] | None = None,
+    ):
         self.put_calls: list[PutCall] = []
         self._put_impl = put_impl
+        self._existing_paths: set[str] = set(existing_paths or set())
+
+    def stat(self, remote_path: str) -> None:
+        if remote_path not in self._existing_paths:
+            raise FileNotFoundError(remote_path)
 
     def putfo(self, file_obj, remote_path: str) -> None:  # type: ignore[no-untyped-def]
         content = file_obj.read()
         if self._put_impl is not None:
             self._put_impl(content, remote_path)
+        self._existing_paths.add(remote_path)
         self.put_calls.append(PutCall(remote_path=remote_path, content_bytes=content))
 
     def __enter__(self) -> "FakeSFTPClient":
@@ -46,6 +57,17 @@ class FakeSFTPHook:
 
     def get_conn(self) -> FakeSFTPClient:
         return self._client
+
+
+class FakeVariable:
+    def __init__(self, initial: dict[str, str] | None = None):
+        self._store: dict[str, str] = dict(initial or {})
+
+    def get(self, key: str, default_var: str | None = None) -> str | None:
+        return self._store.get(key, default_var)
+
+    def set(self, key: str, value: str) -> None:
+        self._store[key] = value
 
 
 def make_email_with_attachments(
@@ -113,12 +135,14 @@ def test_unflags_mail_after_successful_processing_and_uploads_xml_bytes(monkeypa
         raise AssertionError(f"Unexpected IMAP criteria: {criteria!r}")
 
     sftp_client = FakeSFTPClient()
+    fake_var = FakeVariable({"kantinedata_file_counter": "0"})
 
     def fake_sftp_hook_factory(conn_id: str):
         return FakeSFTPHook(conn_id, client=sftp_client)
 
     monkeypatch.setattr(pk_mod, "imap_get_emails_with_uids", fake_imap_get_emails_with_uids)
     monkeypatch.setattr(pk_mod, "SFTPHook", fake_sftp_hook_factory)
+    monkeypatch.setattr(pk_mod, "Variable", fake_var)
 
     pk_mod.process_kantinedata()
 
@@ -129,7 +153,7 @@ def test_unflags_mail_after_successful_processing_and_uploads_xml_bytes(monkeypa
 
     # XML attachment uploaded byte-for-byte, with correct remote path
     assert len(sftp_client.put_calls) == 1
-    assert sftp_client.put_calls[0].remote_path == "/kantine.xml"
+    assert sftp_client.put_calls[0].remote_path == "/EksportedeOrdrer_1.xml"
     assert sftp_client.put_calls[0].content_bytes == xml_bytes
 
     # Success should trigger unflag of the processed UID
@@ -162,12 +186,14 @@ def test_mails_remain_flagged_if_sftp_upload_errors(monkeypatch) -> None:
         raise OSError("SFTP down")
 
     sftp_client = FakeSFTPClient(put_impl=raising_put_impl)
+    fake_var = FakeVariable({"kantinedata_file_counter": "0"})
 
     def fake_sftp_hook_factory(conn_id: str):
         return FakeSFTPHook(conn_id, client=sftp_client)
 
     monkeypatch.setattr(pk_mod, "imap_get_emails_with_uids", fake_imap_get_emails_with_uids)
     monkeypatch.setattr(pk_mod, "SFTPHook", fake_sftp_hook_factory)
+    monkeypatch.setattr(pk_mod, "Variable", fake_var)
 
     with pytest.raises(Exception, match=r"Failed to process 1 email\(s\)\. UIDs: 7"):
         pk_mod.process_kantinedata()
@@ -217,12 +243,14 @@ def test_flagged_mail_is_retrieved_on_rerun_after_previous_failure(monkeypatch) 
             raise OSError("Transient SFTP error")
 
     sftp_client = FakeSFTPClient(put_impl=put_impl)
+    fake_var = FakeVariable({"kantinedata_file_counter": "0"})
 
     def fake_sftp_hook_factory(conn_id: str):
         return FakeSFTPHook(conn_id, client=sftp_client)
 
     monkeypatch.setattr(pk_mod, "imap_get_emails_with_uids", fake_imap_get_emails_with_uids)
     monkeypatch.setattr(pk_mod, "SFTPHook", fake_sftp_hook_factory)
+    monkeypatch.setattr(pk_mod, "Variable", fake_var)
 
     with pytest.raises(Exception):
         pk_mod.process_kantinedata()
@@ -331,8 +359,11 @@ def test_sftp_hook_init_failure_is_raised_and_mail_not_unflagged(monkeypatch) ->
     def raising_sftp_hook_factory(_conn_id: str):
         raise RuntimeError("SFTP credentials invalid")
 
+    fake_var = FakeVariable({"kantinedata_file_counter": "0"})
+
     monkeypatch.setattr(pk_mod, "imap_get_emails_with_uids", fake_imap_get_emails_with_uids)
     monkeypatch.setattr(pk_mod, "SFTPHook", raising_sftp_hook_factory)
+    monkeypatch.setattr(pk_mod, "Variable", fake_var)
 
     with pytest.raises(Exception, match=r"Failed to process 1 email\(s\)\. UIDs: 99"):
         pk_mod.process_kantinedata()
@@ -341,3 +372,38 @@ def test_sftp_hook_init_failure_is_raised_and_mail_not_unflagged(monkeypatch) ->
     assert any(
         c.get("criteria") == "UNSEEN" and c.get("set_flags") == "\\Flagged" for c in calls
     )
+
+
+def test_filename_counter_skips_existing_remote_path(monkeypatch) -> None:
+    xml_bytes = b"<root><a>1</a></root>"
+    msg = make_email_with_attachments(
+        message_id="<msg-skip-existing>",
+        attachments=[(xml_bytes, "application", "xml", "ignored.xml")],
+    )
+
+    def fake_imap_get_emails_with_uids(**kwargs):  # type: ignore[no-untyped-def]
+        criteria = kwargs.get("criteria")
+        if criteria == "FLAGGED":
+            return [], []
+        if criteria == "UNSEEN":
+            return [("1", msg)], []
+        if isinstance(criteria, str) and criteria.startswith("UID "):
+            return [], []
+        raise AssertionError(f"Unexpected IMAP criteria: {criteria!r}")
+
+    # Simulate that EksportedeOrdrer_1.xml already exists on SFTP
+    sftp_client = FakeSFTPClient(existing_paths={"/EksportedeOrdrer_1.xml"})
+
+    def fake_sftp_hook_factory(conn_id: str):
+        return FakeSFTPHook(conn_id, client=sftp_client)
+
+    fake_var = FakeVariable({"kantinedata_file_counter": "0"})
+
+    monkeypatch.setattr(pk_mod, "imap_get_emails_with_uids", fake_imap_get_emails_with_uids)
+    monkeypatch.setattr(pk_mod, "SFTPHook", fake_sftp_hook_factory)
+    monkeypatch.setattr(pk_mod, "Variable", fake_var)
+
+    pk_mod.process_kantinedata()
+
+    assert len(sftp_client.put_calls) == 1
+    assert sftp_client.put_calls[0].remote_path == "/EksportedeOrdrer_2.xml"

--- a/tests/dags/dag_kantinedata/test_process_kantinedata.py
+++ b/tests/dags/dag_kantinedata/test_process_kantinedata.py
@@ -407,3 +407,33 @@ def test_filename_counter_skips_existing_remote_path(monkeypatch) -> None:
 
     assert len(sftp_client.put_calls) == 1
     assert sftp_client.put_calls[0].remote_path == "/EksportedeOrdrer_2.xml"
+
+
+def test_filename_counter_wraps_after_10(monkeypatch) -> None:
+    sftp_client = FakeSFTPClient()
+    fake_var = FakeVariable({"kantinedata_file_counter": "10"})
+    monkeypatch.setattr(pk_mod, "Variable", fake_var)
+
+    filename = pk_mod._allocate_next_filename(sftp_client)
+
+    assert filename == "EksportedeOrdrer_1.xml"
+
+
+def test_filename_counter_wraps_and_skips_existing(monkeypatch) -> None:
+    sftp_client = FakeSFTPClient(existing_paths={"/EksportedeOrdrer_1.xml"})
+    fake_var = FakeVariable({"kantinedata_file_counter": "10"})
+    monkeypatch.setattr(pk_mod, "Variable", fake_var)
+
+    filename = pk_mod._allocate_next_filename(sftp_client)
+
+    assert filename == "EksportedeOrdrer_2.xml"
+
+
+def test_filename_counter_raises_when_all_10_slots_taken(monkeypatch) -> None:
+    existing = {f"/EksportedeOrdrer_{i}.xml" for i in range(1, 11)}
+    sftp_client = FakeSFTPClient(existing_paths=existing)
+    fake_var = FakeVariable({"kantinedata_file_counter": "10"})
+    monkeypatch.setattr(pk_mod, "Variable", fake_var)
+
+    with pytest.raises(RuntimeError, match=r"No available Kantinedata filename slots"):
+        pk_mod._allocate_next_filename(sftp_client)


### PR DESCRIPTION
Use monotonic counter for filename number extensions. Add airflow var to contain current count.
Check SFTP for collision before allocating file names - update var if outdated. Improve docstrings.
Add test for filename collision var update.