### PR TITLE
Use new cert handling

### DIFF
--- a/dags/dag_modregning/process_modregning.py
+++ b/dags/dag_modregning/process_modregning.py
@@ -6,7 +6,6 @@ from airflow.models import Variable
 from airflow.operators.python import get_current_context
 from airflow.providers.sftp.hooks.sftp import SFTPHook
 from rkdigi.email_handling import EmailSender
-from kombit_client.integrations.sf1491.ydelse_liste_hent import YdelseListeHentClient
 
 from dag_modregning.modregning_data import (
     df_to_excel_bytes,
@@ -71,17 +70,23 @@ def process_modregning() -> None:
         logger.info("After extracting unique CPRs")
 
         rows: list[list[str]] = []
-        for cpr in cpr_list:
-            logger.info(f"Processing CPR: {mask_cpr(cpr)}")
-            try:
-                logger.info("Before calling YdelseListeHentClient")
-                ydelse_client = YdelseListeHentClient(cvr="29189668")
-                payload = ydelse_client.effektuering_hent(cpr=cpr, start_dato=start_dato, slut_dato=slut_dato)
-                ydelser = extract_ydelser_from_serviceplatform_response(payload=payload)
-                rows.append([cpr, ", ".join(sorted(ydelser)) if ydelser else ""])
-            except Exception as e:
-                logger.error(f"Failed for CPR {mask_cpr(cpr)}: {e}")
-                rows.append([cpr, ""])
+
+        # ## vvv New serviceplatformen / kombit cert handling vvv ## #
+        from utils.kombit import TempClientCert
+        from kombit_client.integrations.sf1491 import YdelseListeHentClient
+        with TempClientCert() as client_cert_path:
+            for cpr in cpr_list:
+                logger.info(f"Processing CPR: {mask_cpr(cpr)}")
+                try:
+                    logger.info("Before calling YdelseListeHentClient")
+                    ydelse_client = YdelseListeHentClient(client_certificate_file_path=client_cert_path)
+                    payload = ydelse_client.effektuering_hent(cpr=cpr, start_dato=start_dato, slut_dato=slut_dato)
+                    ydelser = extract_ydelser_from_serviceplatform_response(payload=payload)
+                    rows.append([cpr, ", ".join(sorted(ydelser)) if ydelser else ""])
+                except Exception as e:
+                    logger.error(f"Failed for CPR {mask_cpr(cpr)}: {e}")
+                    rows.append([cpr, ""])
+        # ## ^^^ New serviceplatformen / kombit cert handling ^^^ ## #
 
         out_df = pd.DataFrame(rows, columns=["cpr", "YdelseNavn"])
         excel_bytes = df_to_excel_bytes(out_df)


### PR DESCRIPTION
Har tilføjet ny håndtering af kombit / serviceplatformen certs (det er på prod og jeg har allerede merged det ind i din brach)

Fejlen var at der manglede et led i cert chain, som beskrevet [her](https://github.com/[KvalitetsIT/kombit-sf1520-example](https://github.com/KvalitetsIT/kombit-sf1520-example#installer-certifikat-i-trust-store)#installer-certifikat-i-trust-store)

Det var også fejlen lokalt, ved ikke hvorfor der ikke kom en exception - men i Kubernetes fik jeg en exception der viste at det her var problemet.

Der er to måder at løse det på:
1. Den måde Henrik beskrev (tilføj alle led i cert)
2. Installer alle højere led i trust store

Jeg har løst det med 2,  kan ses [her](https://github.com/Randers-Kommune-Digitalisering/airflow/blob/prod/Dockerfile#L25-L27)

Jeg har tilføjet en hjælper-klasse der skriver client cert til utils [her](https://github.com/Randers-Kommune-Digitalisering/airflow/blob/prod/dags/utils/kombit.py)

Har tilføjet alle certs (undtagen client selvfølgelig) til en delt mappe der hedder [certs](https://github.com/Randers-Kommune-Digitalisering/airflow/tree/prod/dags/certs)

Har tilføjet env vars der trækker fra din secret i kombit-cpr-replika, de er [her](https://github.com/Randers-Kommune-Digitalisering/kithosting-randers-kommune-apps/blob/prod/airflow/values.yaml#L130-L143)

**OBS!** Hvis du sletter kombit-cpr-replika så virker det ikke længere - men du skal bare rykke den secret over i sealed-secrets når/hvis du sletter den, så virker det hele stadig.