### PR TITLE
Ændringsforslag implementeret.

### DIFF
--- a/dags/dag_modregning/dag_modregning.py
+++ b/dags/dag_modregning/dag_modregning.py
@@ -16,7 +16,7 @@ with DAG(
     max_active_runs=1,
     default_args=dag_args,
     description="Fetch CPR list from SFTP, query Serviceplatform, and email Modregning report",
-    tags=["modregning", "sftp", "http", "email"],
+    tags=["modregning", "sftp", "serviceplatform", "email"],
 ) as dag:
 
     run_modregning = PythonOperator(

--- a/dags/dag_modregning/modregning_data.py
+++ b/dags/dag_modregning/modregning_data.py
@@ -9,6 +9,7 @@ from airflow.providers.sftp.hooks.sftp import SFTPHook
 
 logger = logging.getLogger(__name__)
 
+# TODO: Overvej at flytte pseudo env vars til airflow vars - ellers blot slet kommentar
 DEFAULT_CPR_COLUMN = "ID-nummer"
 
 EXCLUDED_YDELSE_NAVNE: set[str] = {
@@ -44,7 +45,7 @@ def get_latest_excel_info(
 
     matched = [f for f in files if fnmatch.fnmatch(f.filename.lower(), pattern.lower())]
     if not matched:
-        logger.error(f'No Excel files found in "{directory}" matching "{pattern}"')
+        logger.error(f'No Excel files found in "{directory}" matching "{pattern.lower()}"')
         return None
 
     latest = max(matched, key=lambda f: f.st_mtime)
@@ -65,7 +66,7 @@ def read_excel_from_sftp(
     :param sftp_hook: Airflow SFTPHook used to obtain an SFTP connection.
     :param remote_path: Full remote path to the Excel file to read.
     :param dtype: Optional dtype mapping forwarded to `pandas.read_excel`.
-    :param sheet_name: Sheet name
+    :param sheet_name: Sheet name or index to read, forwarded to `pandas.read_excel` (default: 0, i.e. first sheet).
     :return: DataFrame containing the parsed Excel sheet.
     """
 
@@ -76,19 +77,6 @@ def read_excel_from_sftp(
         data = remote_file.read()
 
     return pd.read_excel(io.BytesIO(data), dtype=dtype, sheet_name=sheet_name)
-
-
-def mask_cpr(cpr: object) -> str:
-    """
-    Mask CPR for logging (never log full CPR).
-
-    :param cpr: CPR-like value.
-    :return: Masked CPR like 'DDMMYYxxxx' or 'invalid'.
-    """
-    cpr_str = str(cpr).strip().replace("-", "").replace(" ", "").zfill(10)
-    if len(cpr_str) == 10 and cpr_str.isdigit():
-        return f"{cpr_str[:6]}xxxx"
-    return "invalid"
 
 
 def _normalize_cpr(value: object) -> str | None:
@@ -104,9 +92,13 @@ def _normalize_cpr(value: object) -> str | None:
     s = str(value).strip().replace("-", "").replace(" ", "")
     if not s.isdigit():
         return None
+    
+    if len(s) != 10:
+        return None
+    
+    # TODO: Overvej at validere CPR yderligere, fx ved at tjekke fødselsdato og kontrolciffer - vi har en regex til dette
 
-    s = s.zfill(10)
-    return s if len(s) == 10 else None
+    return s
 
 
 def extract_unique_cprs(
@@ -123,13 +115,9 @@ def extract_unique_cprs(
     if column not in df.columns:
         raise ValueError(f'Expected column "{column}" not found. Columns: {df.columns.tolist()}')
 
-    cprs: list[str] = []
-    for raw in df[column].tolist():
-        normalized = _normalize_cpr(raw)
-        if normalized:
-            cprs.append(normalized)
-
-    unique = sorted(set(cprs))
+    normalized = df[column].map(_normalize_cpr)
+    # `dropna()` removes None/NaN, then `unique()` is faster than `set(...)` for large Series.
+    unique = sorted(str(cpr) for cpr in normalized.dropna().unique())
     logger.info(f"Extracted {len(unique)} unique CPRs from Excel")
     return unique
 
@@ -156,7 +144,7 @@ def extract_ydelser_from_serviceplatform_response(payload: dict[str, Any]) -> tu
         for ydelse in ydelse_list:
             found_any_ydelse = True
 
-            navn = (ydelse.get("BevilgetYdelse", {}) or {}).get("YdelseNavn", "")
+            navn = ydelse.get("BevilgetYdelse", {}).get("YdelseNavn", "")
             if not isinstance(navn, str):
                 continue
 
@@ -192,11 +180,13 @@ def df_to_excel_bytes(df: pd.DataFrame, sheet_name: str = "Modregning") -> bytes
         for col_idx, col_name in enumerate(df.columns, start=1):
             series = df[col_name].fillna("").astype(str)
 
-            max_len = series.map(len).max() if not series.empty else 0
-            if pd.isna(max_len):
+            if series.empty:
                 max_len = 0
+            else:
+                max_len_raw = series.map(len).max()
+                max_len = int(max_len_raw) if pd.notna(max_len_raw) else 0
 
-            max_len = max(int(max_len), len(str(col_name)))
+            max_len = max(max_len, len(str(col_name)))
             ws.column_dimensions[get_column_letter(col_idx)].width = min(max_len + padding, max_width)
 
     return output.getvalue()

--- a/dags/dag_modregning/modregning_data.py
+++ b/dags/dag_modregning/modregning_data.py
@@ -6,23 +6,21 @@ from datetime import datetime, timezone
 from typing import Any
 from openpyxl.utils import get_column_letter
 from airflow.providers.sftp.hooks.sftp import SFTPHook
+from airflow.models import Variable
 
 logger = logging.getLogger(__name__)
 
-# TODO: Overvej at flytte pseudo env vars til airflow vars - ellers blot slet kommentar
-DEFAULT_CPR_COLUMN = "ID-nummer"
+# the excluded_ydelse_name list will from now on be maintained in Airflow Variables, so it can be updated without code changes
+excluded_cfg = Variable.get(
+    "modregning_excluded_ydelse_list",
+    default_var='{"excluded_ydelse_name": []}',
+    deserialize_json=True,
+)
 
-EXCLUDED_YDELSE_NAVNE: set[str] = {
-    "Sygedagpenge til virksomhed",
-    "Sygedagpenge til borger",
-    "LAS § 81 a - Enkeltydelse til udsættelsestruede lejere",
-    "DAL § 86 - Tilskud pasning af egne børn",
-    "Ressourceforløbsydelse under ressourceforløb, Uddannelseshjælp",
-    "Fleksløntilskud",
-    "Ledighedsydelse",
-    "Ressourceforløbsydelse under ressourceforløb",
-    "Ressourceforløbsydelse, jobafklaring",
-    "Fleksløntilskud, Ledighedsydelse",
+excluded_ydelse_name = {
+    x.strip()
+    for x in excluded_cfg.get("excluded_ydelse_name", [])
+    if x and isinstance(x, str)
 }
 
 
@@ -92,10 +90,10 @@ def _normalize_cpr(value: object) -> str | None:
     s = str(value).strip().replace("-", "").replace(" ", "")
     if not s.isdigit():
         return None
-    
+
     if len(s) != 10:
         return None
-    
+
     # TODO: Overvej at validere CPR yderligere, fx ved at tjekke fødselsdato og kontrolciffer - vi har en regex til dette
 
     return s
@@ -103,7 +101,7 @@ def _normalize_cpr(value: object) -> str | None:
 
 def extract_unique_cprs(
     df: pd.DataFrame,
-    column: str = DEFAULT_CPR_COLUMN,
+    column: str = "ID-nummer",
 ) -> list[str]:
     """
     Extract unique CPR numbers from an Excel DataFrame column.
@@ -152,7 +150,7 @@ def extract_ydelser_from_serviceplatform_response(payload: dict[str, Any]) -> tu
             if not navn:
                 continue
 
-            if navn in EXCLUDED_YDELSE_NAVNE:
+            if navn in excluded_ydelse_name:
                 continue
 
             ydelser.add(navn)

--- a/dags/dag_modregning/modregning_data.py
+++ b/dags/dag_modregning/modregning_data.py
@@ -94,8 +94,6 @@ def _normalize_cpr(value: object) -> str | None:
     if len(s) != 10:
         return None
 
-    # TODO: Overvej at validere CPR yderligere, fx ved at tjekke fødselsdato og kontrolciffer - vi har en regex til dette
-
     return s
 
 

--- a/dags/dag_modregning/process_modregning.py
+++ b/dags/dag_modregning/process_modregning.py
@@ -11,7 +11,6 @@ from dag_modregning.modregning_data import (
     extract_unique_cprs,
     extract_ydelser_from_serviceplatform_response,
     get_latest_excel_info,
-    mask_cpr,
     read_excel_from_sftp,
 )
 
@@ -20,6 +19,7 @@ logger = logging.getLogger(__name__)
 
 def _resolve_date_range() -> tuple[str, str]:
     """
+    # TODO: Beskriv hvordan startDato og slutDato skal bestemmes. Den vælger ikke month-to-date men i stedet sidste måned.
     Resolve startDato/slutDato as ISO dates based on logical_date (default: month-to-date).
     """
     ctx = get_current_context()
@@ -70,19 +70,18 @@ def process_modregning() -> None:
         rows: list[list[str]] = []
         
         from utils.kombit import TempClientCert
-        from kombit_client.integrations.sf1491 import YdelseListeHentClient # Virker kun med Lazy import. Hvis du sætter import ved toppen så fryser hele DAG'en 
+        from kombit_client.integrations.sf1491 import YdelseListeHentClient # Import lazily to avoid Airflow freezing issue
+
         with TempClientCert() as client_cert_path:
+            ydelse_client = YdelseListeHentClient(client_certificate_file_path=client_cert_path)
             for cpr in cpr_list:
-                masked_cpr = mask_cpr(cpr=cpr)
-                logger.info(f"Processing CPR: {masked_cpr}")
                 try:
-                    ydelse_client = YdelseListeHentClient(client_certificate_file_path=client_cert_path)
                     payload = ydelse_client.effektuering_hent(cpr=cpr, start_dato=start_dato, slut_dato=slut_dato)
 
                     ydelser, found_any = extract_ydelser_from_serviceplatform_response(payload=payload)
 
                     if ydelser:
-                        cell_value = ", ".join(sorted(ydelser)) # Join sorted ydelser into a single string(eg. Forhøjet sats , Grund sats)
+                        cell_value = ", ".join(sorted(ydelser)) # Join sorted ydelser into a single string(e.g. Forhøjet sats , Grund sats)
                     elif found_any:
                         cell_value = ""  # Only filtered ydelser -> empty cell only
                     else:
@@ -91,7 +90,7 @@ def process_modregning() -> None:
                     rows.append([cpr, cell_value])
 
                 except Exception as e:
-                    logger.error(f"Error processing CPR {masked_cpr}: {e}")
+                    logger.error(f"Error during processing: {e}")
                     rows.append([cpr, "Error"])
 
         out_df = pd.DataFrame(rows, columns=["cpr", "YdelseNavn"])

--- a/dags/dag_modregning/process_modregning.py
+++ b/dags/dag_modregning/process_modregning.py
@@ -19,8 +19,14 @@ logger = logging.getLogger(__name__)
 
 def _resolve_date_range() -> tuple[str, str]:
     """
-    # TODO: Beskriv hvordan startDato og slutDato skal bestemmes. Den vælger ikke month-to-date men i stedet sidste måned.
-    Resolve startDato/slutDato as ISO dates based on logical_date (default: month-to-date).
+    Resolve start_dato/slut_dato as ISO dates (YYYY-MM-DD) based on Airflow `logical_date`.
+
+    - `logical_date` is converted to the DAG timezone and truncated to a date.
+    - `start_dato` is set to the 1st day of the previous month relative to `logical_date`.
+    - `slut_dato` is set to `logical_date`.
+
+    Returns:
+        (start_dato, slut_dato) as ISO date strings.
     """
     ctx = get_current_context()
     logical_date = ctx["logical_date"].in_timezone(ctx["dag"].timezone).date()
@@ -35,12 +41,12 @@ def process_modregning() -> None:
     2) Call Serviceplatform for each CPR in date range
     3) Email an Excel report
     """
-    modregning_config = Variable.get("modregning_config", deserialize_json=True)
+    modregning_runtime_config = Variable.get("modregning_runtime_config", deserialize_json=True)
 
-    sftp_dir = modregning_config["sftp_dir"]
-    sender = modregning_config["sender_email"]
-    recipients = modregning_config["recipient_emails"]
-    smtp_server = modregning_config["smtp_server"]
+    sftp_dir = modregning_runtime_config["sftp_dir"]
+    sender = modregning_runtime_config["sender_email"]
+    recipients = modregning_runtime_config["recipient_emails"]
+    smtp_server = modregning_runtime_config["smtp_server"]
 
     start_dato, slut_dato = _resolve_date_range()
     logger.info(f"Modregning date range: {start_dato} -> {slut_dato}")
@@ -68,7 +74,7 @@ def process_modregning() -> None:
         logger.info("After extracting unique CPRs")
 
         rows: list[list[str]] = []
-        
+
         from utils.kombit import TempClientCert
         from kombit_client.integrations.sf1491 import YdelseListeHentClient # Import lazily to avoid Airflow freezing issue
 

--- a/docs/modregning.md
+++ b/docs/modregning.md
@@ -3,7 +3,12 @@
 
 ## Formål
 
-Formålet med jobbet er at hente den nyeste CPR-liste (Excel) fra en SFTP, slå modregningsrelevante ydelser op via Serviceplatform gennem Serviceplatform pakken: ([kombit_client](https://pypi.org/project/kombit-client/))  , og sende en Excel-rapport på email.
+# TODO: Beskriv formålet bedre. Hvilke ydelser behandles der? Hvorfor?
+# TODO: Beskriv CPR-listen (Hvad indeholder den? I hvilket format?)
+# TODO: Beskriv SFTP-setup - hvor kommer data fra? Tilføj SFTP til afhængiheder - løsningen virker ikke uden.
+# TODO: Beskriv schedule ift. dato-interval beregning
+
+Formålet med jobbet er at hente den nyeste CPR-liste (Excel) fra en SFTP, slå modregningsrelevante ydelser op via Serviceplatform gennem Serviceplatform pakken: ([kombit_client](https://pypi.org/project/kombit-client/)), og sende en Excel-rapport på email.
 
 ## Beskrivelse
 

--- a/docs/modregning.md
+++ b/docs/modregning.md
@@ -3,12 +3,8 @@
 
 ## Formål
 
-# TODO: Beskriv formålet bedre. Hvilke ydelser behandles der? Hvorfor?
-# TODO: Beskriv CPR-listen (Hvad indeholder den? I hvilket format?)
-# TODO: Beskriv SFTP-setup - hvor kommer data fra? Tilføj SFTP til afhængiheder - løsningen virker ikke uden.
-# TODO: Beskriv schedule ift. dato-interval beregning
+Formålet med jobbet er at understøtte Betalingskontorets behov for at sammenholde personer (fra en CPR-liste) med oplysninger om ydelsesudbetalinger hentet via Serviceplatform pakken: ([kombit_client](https://pypi.org/project/kombit-client/)) i et givent dato-interval. Jobbet henter den nyeste CPR-liste (Excel) fra SFTP, slår relevante ydelsestyper op pr. CPR i Serviceplatformen og genererer en Excel-rapport, som sendes på email. Rapporten bruges som grundlag for kontrol og opfølgning på personer, der modtager bestemte ydelsestyper (herunder at kunne frasortere ydelsestyper via excluded-listen).
 
-Formålet med jobbet er at hente den nyeste CPR-liste (Excel) fra en SFTP, slå modregningsrelevante ydelser op via Serviceplatform gennem Serviceplatform pakken: ([kombit_client](https://pypi.org/project/kombit-client/)), og sende en Excel-rapport på email.
 
 ## Beskrivelse
 
@@ -20,7 +16,6 @@ Koden består af et DAG-job, der udfører følgende trin:
 - Finder nyeste Excel-fil på SFTP (default mønster `*.xlsx`) i den mappe, der er angivet i `modregning_config["sftp_dir"]`
 - Læser Excel-arket og udtrækker unikke CPR-numre fra kolonnen `ID-nummer`
   - CPR normaliseres til 10 cifre (ugyldige værdier ignoreres)
-  - CPR maskeres i logs (fx `DDMMYYxxxx`)
 - Kalder Serviceplatform (SF1491) for hver CPR i dato-intervallet og udtrækker `YdelseNavn`
   - Visse ydelsestyper filtreres fra via `EXCLUDED_YDELSE_NAVNE` listen i koden, hvorved YdelseNavn vil være tom
   - Hvis der ingen ydelser findes i svaret sættes feltet til `Ingen Ydelse`
@@ -30,10 +25,20 @@ Koden består af et DAG-job, der udfører følgende trin:
 **Dataflow:**
 - Excel på SFTP → CPR-liste → Serviceplatform-opslag → Excel-rapport → Email
 
+**Forudsætning(manuel proces):**
+
+Den 15. i hver måned uploader Betalingskontoret en ny CPR-liste (Excel) til SFTP-mappen. CPR-listen bruges eom input til modregningsopslag.
+Excel-filen skal indeholde kolonnen `ID-nummer` (CPR). 
+Jobbet bruger den nyeste tilgængelige Excel-fil på SFTP; hvis der ikke ligger en opdateret fil, kan jobbet ikke gennemføre rapporten som forventet. Betalingskontoret vedligeholder desuden listen `modregning_excluded_ydelse_list` (tilføj/fjern ydelser efter behov).
+
 ## Afhængigheder
+
+### Kombit_client(Serviceplatformen)
 
 Da koden anvender kombit_client pakken kræver det at man sætter **`CLIENT_CERT_PUBLIC_KEY`** og **`CLIENT_CERT_PRIVATE_KEY`**. De resterende certifikater fra Serviceplatformen ligger i mappen **`Certificates`**
 
+
+### Airflow Connections
 :key: | **Airflow Connections**
 
 **SFTP:**
@@ -46,10 +51,12 @@ Bruges som `Connection id` i Airflow til at hente host, user, pass og port til S
 *Required felter*:
   - Connection id, Host, Username, Password og Port(22)
 
+
+### Airflow Variables 
 :key: | **Airflow Variables**
 
-**Modregning konfiguration (SFTP + email):**
-- **Key**: `modregning_config`
+**Modregning Runtime Konfiguration (SFTP + email + SMTP ):**
+- **Key**: `modregning_runtime_config`
 
 *Required felter*:
   - `sftp_dir` (remote mappe på SFTP)
@@ -65,9 +72,37 @@ Eksempel:
   "recipient_emails": ["modtager1@randers.dk", "modtager2@randers.dk"],
   "smtp_server": "smtp.example.local"
 }
+```
 
-## Schedule
+**Modregning Excluded Ydelse navne liste:**
+- **Key**: `modregning_excluded_ydelse_list`
 
-Schedule er sat op til at køre automatisk på følgende tidspunkter:
+*Required felter*:
+  - `excluded_ydelse_name` (Værdier fra ydelser som skal excludes fra udtrækket)
 
-- **Tidspunkt:** Kl. 09:00 den 15. i hver måned
+Eksempel:
+```json
+{
+  "excluded_ydelse_name": [
+    "Sygedagpenge til virksomhed",
+    "Sygedagpenge til borger"
+  ]
+}
+```
+
+## Schedule og dato interval
+
+
+DAG’en er planlagt til at køre kl. 09:00 den 15. i hver måned. For hver kørsel beregnes dato-intervallet ud fra Airflows `logical_date `(konverteret til DAG’ens timezone og trunkeret til dato):
+
+- `slut_dato` = datoen for `logical_date`
+- `start_dato` = 1. dag i måneden før `logical_date`
+
+
+Det betyder, at en planlagt kørsel den 15. i måneden typisk dækker perioden fra 1. i forrige måned til 15. i indeværende måned (inkl.).
+
+**Eksempel:**
+
+Kørsel: 2026-05-15 kl. 09:00 --->  `logical_date` = 2026-05-15
+- `start_dato` = 2026-04-01
+- `slut_dato` = 2026-05-15


### PR DESCRIPTION
# Changelog skrevet af Copilot:

- **CPR-normalisering & udtræk**
  - Strammer CPR-normalisering: accepterer nu kun værdier med præcis 10 cifre (ingen `zfill`/padding af kortere værdier) i modregning_data.py.
  - Optimerer udtræk af unikke CPR’er ved at skifte fra manuel liste/set-loop til Pandas `map(...)` + `dropna().unique()` i modregning_data.py.

- **Serviceplatform parsing**
  - Ændrer udtræk af `YdelseNavn` til at bruge `ydelse.get("BevilgetYdelse", {}).get(...)` uden ekstra `( ... or {} )` guard i modregning_data.py (bemærk: hvis `BevilgetYdelse` kan være `None`, håndteres det ikke længere eksplicit).

- **Excel-eksport (kolonnebredder)**
  - Gør beregning af kolonnebredde mere robust ved tomme kolonner og `NaN` ved at normalisere `max_len` til en int før sammenligning i modregning_data.py.

- **Modregning-process: client-init & logs**
  - Initialiserer `YdelseListeHentClient` én gang uden for CPR-loopet (reducerer overhead) i process_modregning.py.
  - Stopper med at logge CPR (masket/umasket) pr. iteration og logger fejl uden CPR-værdi i process_modregning.py.
  - Tilføjer TODO om at beskrive/afklare dato-interval-beregningen i process_modregning.py.
  - Opdaterer kommentaren om lazy import til engelsk.

- **SFTP/Excel-read (små justeringer)**
  - Justerer fejlbesked ved manglende match til at vise `pattern.lower()` i modregning_data.py.
  - Præciserer docstring for `sheet_name` i modregning_data.py.

- **Dokumentation**
  - Tilføjer TODO’er om at uddybe formål, CPR-listeformat, SFTP-setup og schedule/dato-interval i modregning.md.
  - Bemærkning: Dokumentet siger stadig at “CPR maskeres i logs” i modregning.md, men koden logger ikke CPR pr. iteration i process_modregning.py.