### PR TITLE
Refactor address lookup logic in district control helper to handle None values

### DIFF
--- a/dags/dag_novax_district_control/check_and_update_district.py
+++ b/dags/dag_novax_district_control/check_and_update_district.py
@@ -167,7 +167,10 @@ def check_and_update_district(dry_run: bool, ignore_cprs: list) -> None:
                 is_protected_address=bool(cpr_info["is_protected_address"]),
             )
 
-            address_info = dataforsyning_client.get_address_by_id(cpr_info['address_uuid'])
+            address_uuid = cpr_info['address_uuid']
+            address_info = None
+            if address_uuid is not None:
+                address_info = dataforsyning_client.get_address_by_id(address_uuid)
 
             # Address + district updates
             is_new_address_set = False
@@ -180,7 +183,7 @@ def check_and_update_district(dry_run: bool, ignore_cprs: list) -> None:
                 logger.warning(
                     "Skipping address lookup and clearing district for Name ID %s due to unexpected Dataforsyning results (adresse_uuid=%s)",
                     entry.ID,
-                    cpr_info["address_uuid"],
+                    address_uuid,
                 )
 
                 is_new_district = clear_district_due_to_missing_address(

--- a/dags/dag_novax_district_control/check_and_update_district.py
+++ b/dags/dag_novax_district_control/check_and_update_district.py
@@ -181,7 +181,7 @@ def check_and_update_district(dry_run: bool, ignore_cprs: list) -> None:
 
             if address_info is None:
                 logger.warning(
-                    "Skipping address lookup and clearing district for Name ID %s due to unexpected Dataforsyning results (adresse_uuid=%s)",
+                    "Skipping address lookup and clearing district for Name ID %s due to unexpected address information (address_uuid=%s)",
                     entry.ID,
                     address_uuid,
                 )

--- a/dags/dag_novax_district_control/check_and_update_district_followup.py
+++ b/dags/dag_novax_district_control/check_and_update_district_followup.py
@@ -94,9 +94,9 @@ def check_and_update_district_followup(dry_run: bool, ignore_cprs: list, **conte
 
             if address_info is None:
                 logger.warning(
-                    "Skipping address lookup + district update for Name ID %s due to unexpected Dataforsyning results (adresse_uuid=%s)",
+                    "Skipping address lookup + district update for Name ID %s due to unexpected address information (address_uuid=%s)",
                     entry.ID,
-                    cpr_info["address_uuid"],
+                    address_uuid,
                 )
 
             else:

--- a/dags/dag_novax_district_control/check_and_update_district_followup.py
+++ b/dags/dag_novax_district_control/check_and_update_district_followup.py
@@ -8,7 +8,6 @@ from dag_novax_district_control.clients.district_map_client import DistrictMapDB
 from dag_novax_district_control.clients.cpr_client import CPRClient
 from dag_novax_district_control.model import Name, NameDetails, Remind
 from dag_novax_district_control.district_update_helpers import (
-    clear_district_due_to_missing_address,
     ensure_active,
     is_valid_cpr,
     update_address_from_dataforsyning,
@@ -81,7 +80,10 @@ def check_and_update_district_followup(dry_run: bool, ignore_cprs: list, **conte
                 is_protected_address=bool(cpr_info["is_protected_address"]),
             )
 
-            address_info = dataforsyning_client.get_address_by_id(cpr_info["address_uuid"])
+            address_uuid = cpr_info['address_uuid']
+            address_info = None
+            if address_uuid is not None:
+                address_info = dataforsyning_client.get_address_by_id(address_uuid)
 
             # Address + district updates
             is_new_address_set = False
@@ -92,15 +94,9 @@ def check_and_update_district_followup(dry_run: bool, ignore_cprs: list, **conte
 
             if address_info is None:
                 logger.warning(
-                    "Skipping address lookup and clearing district for Name ID %s due to unexpected Dataforsyning results (adresse_uuid=%s)",
+                    "Skipping address lookup + district update for Name ID %s due to unexpected Dataforsyning results (adresse_uuid=%s)",
                     entry.ID,
                     cpr_info["address_uuid"],
-                )
-
-                is_new_district = clear_district_due_to_missing_address(
-                    entry=entry,
-                    now_dt=now_dt,
-                    now_time=now_time,
                 )
 
             else:

--- a/dags/dag_novax_district_control/clients/cpr_client.py
+++ b/dags/dag_novax_district_control/clients/cpr_client.py
@@ -34,11 +34,12 @@ class CPRClient:
         res.raise_for_status()
         data = res.json()
 
-        address_uuid = data['aktuelAdresse'].get('adresseUUID', '')
+        address_uuid = data.get('aktuelAdresse', {}).get('adresseUUID')
         protected = data.get('adressebeskyttelse', {}).get('beskyttet')
 
-        if not isinstance(protected, bool) or not isinstance(address_uuid, str) or not len(address_uuid) == 36:
-            raise ValueError(f"Unexpected response format for CPR {cpr_number[:6]}-XXXX")
+        is_valid_uuid = isinstance(address_uuid, str) and len(address_uuid) == 36
+        if not isinstance(protected, bool) or (address_uuid is not None and not is_valid_uuid):
+            raise ValueError(f"Unexpected response format for CPR {cpr_number[:6]}-XXXX, got: {data}")
 
         return {
             'address_uuid': address_uuid,

--- a/dags/dag_novax_district_control/clients/cpr_client.py
+++ b/dags/dag_novax_district_control/clients/cpr_client.py
@@ -39,7 +39,7 @@ class CPRClient:
 
         is_valid_uuid = isinstance(address_uuid, str) and len(address_uuid) == 36
         if not isinstance(protected, bool) or (address_uuid is not None and not is_valid_uuid):
-            raise ValueError(f"Unexpected response format for CPR {cpr_number[:6]}-XXXX, got: {data}")
+            raise ValueError(f"Unexpected response format for CPR {cpr_number[:6]}-XXXX (protected={protected!r}, address_uuid={address_uuid!r})")
 
         return {
             'address_uuid': address_uuid,


### PR DESCRIPTION
No longer clear district if address uid lookup is None for followup job Clear district for normal job if address uid lookup is None -> no longer raises Exception (aligns with Dataforsyning lookup error handling)