### PR TITLE
Fix default_var type for excluded_cfg in modregning_data

### DIFF
--- a/dags/dag_modregning/dag_modregning.py
+++ b/dags/dag_modregning/dag_modregning.py
@@ -1,7 +1,7 @@
 from airflow import DAG
 from airflow.operators.python import PythonOperator
 from pendulum import datetime, timezone
-
+from airflow.models.param import Param
 from utils.config import DEFAULT_DAG_ARGS
 from dag_modregning.process_modregning import process_modregning
 
@@ -17,6 +17,20 @@ with DAG(
     default_args=dag_args,
     description="Fetch CPR list from Mailbox, query Serviceplatform, and email Modregning report",
     tags=["modregning", "mailbox", "serviceplatform", "email"],
+    params={
+        "start_dato": Param(
+            type="string",  # required start_dato
+            minLength=10,
+            maxLength=10,
+            description="Påkrævet startdato i format YYYY-MM-DD, fx 2026-06-01",
+        ),
+        "slut_dato": Param(
+            type="string",  # required slut_dato
+            minLength=10,
+            maxLength=10,
+            description="Påkrævet slutdato i format YYYY-MM-DD, fx 2026-07-27",
+        ),
+    },
 ) as dag:
 
     run_modregning = PythonOperator(

--- a/dags/dag_modregning/dag_modregning.py
+++ b/dags/dag_modregning/dag_modregning.py
@@ -17,16 +17,18 @@ with DAG(
     tags=["modregning", "mailbox", "serviceplatform", "email"],
     params={
         "start_date": Param(
-            type="string",  # required start_date
+            default=None,
+            type=["null", "string"],
             minLength=10,
             maxLength=10,
-            description="Påkrævet startdato i format YYYY-MM-DD, fx 2026-06-01",
+            description="Valgfri startdato i format YYYY-MM-DD fx 2026-06-01. Hvis tom, beregnes automatisk.",
         ),
         "end_date": Param(
-            type="string",  # required end_date
+            default=None,
+            type=["null", "string"],
             minLength=10,
             maxLength=10,
-            description="Påkrævet slutdato i format YYYY-MM-DD, fx 2026-07-27",
+            description="Valgfri slutdato i format YYYY-MM-DD fx 2026-07-27. Hvis tom, beregnes automatisk.",
         ),
     },
 ) as dag:

--- a/dags/dag_modregning/dag_modregning.py
+++ b/dags/dag_modregning/dag_modregning.py
@@ -1,6 +1,5 @@
 from airflow import DAG
 from airflow.operators.python import PythonOperator
-from pendulum import datetime, timezone
 from airflow.models.param import Param
 from utils.config import DEFAULT_DAG_ARGS
 from dag_modregning.process_modregning import process_modregning
@@ -10,7 +9,6 @@ dag_args["retries"] = 0
 
 with DAG(
     dag_id="dag_modregning",
-    start_date=datetime(year=2026, month=5, day=5, tz=timezone("Europe/Copenhagen")),
     schedule=None,
     catchup=False,
     max_active_runs=1,
@@ -18,14 +16,14 @@ with DAG(
     description="Fetch CPR list from Mailbox, query Serviceplatform, and email Modregning report",
     tags=["modregning", "mailbox", "serviceplatform", "email"],
     params={
-        "start_dato": Param(
-            type="string",  # required start_dato
+        "start_date": Param(
+            type="string",  # required start_date
             minLength=10,
             maxLength=10,
             description="Påkrævet startdato i format YYYY-MM-DD, fx 2026-06-01",
         ),
-        "slut_dato": Param(
-            type="string",  # required slut_dato
+        "end_date": Param(
+            type="string",  # required end_date
             minLength=10,
             maxLength=10,
             description="Påkrævet slutdato i format YYYY-MM-DD, fx 2026-07-27",

--- a/dags/dag_modregning/modregning_data.py
+++ b/dags/dag_modregning/modregning_data.py
@@ -11,7 +11,7 @@ logger = logging.getLogger(__name__)
 # the excluded_ydelse_name list will from now on be maintained in Airflow Variables, so it can be updated without code changes
 excluded_cfg = Variable.get(
     "modregning_excluded_ydelse_list",
-    default_var='{"excluded_ydelse_name": []}',
+    default_var={"excluded_ydelse_name": []},  # Default var skal være et dict og ikke en streng ellers fejler excluded_cfg.get("excluded_ydelse_name", [])
     deserialize_json=True,
 )
 

--- a/dags/dag_modregning/modregning_data.py
+++ b/dags/dag_modregning/modregning_data.py
@@ -8,18 +8,19 @@ from rkdigi.email_handling import EmailReader
 
 logger = logging.getLogger(__name__)
 
-# the excluded_ydelse_name list will from now on be maintained in Airflow Variables, so it can be updated without code changes
-excluded_cfg = Variable.get(
-    "modregning_excluded_ydelse_list",
-    default_var={"excluded_ydelse_name": []},  # Default var skal være et dict og ikke en streng ellers fejler excluded_cfg.get("excluded_ydelse_name", [])
-    deserialize_json=True,
-)
 
-excluded_ydelse_name = {
-    x.strip()
-    for x in excluded_cfg.get("excluded_ydelse_name", [])
-    if x and isinstance(x, str)
-}
+def get_excluded_ydelse_names() -> set[str]:
+    excluded_cfg = Variable.get(
+        "modregning_excluded_ydelse_list",
+        default_var={"excluded_ydelse_name": []},
+        deserialize_json=True,
+    )
+
+    return {
+        x.strip()
+        for x in excluded_cfg.get("excluded_ydelse_name", [])
+        if isinstance(x, str) and x
+    }
 
 
 def _normalize_cpr(value: str | None) -> str | None:
@@ -94,7 +95,7 @@ def extract_ydelser_from_serviceplatform_response(payload: dict[str, Any]) -> tu
             if not navn:
                 continue
 
-            if navn in excluded_ydelse_name:
+            if navn in get_excluded_ydelse_names():
                 continue
 
             ydelser.add(navn)

--- a/dags/dag_modregning/process_modregning.py
+++ b/dags/dag_modregning/process_modregning.py
@@ -18,24 +18,34 @@ from dag_modregning.modregning_data import (
 logger = logging.getLogger(__name__)
 
 
-def _resolve_month_interval() -> tuple[str, str]:
+def _resolve_date_range() -> tuple[str, str]:
     """
-    Resolve and validate month interval from DAG runtime params.
+    Resolve and validate date interval from DAG runtime params.
 
-    :return: Tuple containing (start_date, end_date).
-    :raises AirflowFailException: If required params are missing or the interval is invalid.
+    If both start_date and end_date are provided, use them.
+    If neither is provided, derive defaults from logical_date in DAG timezone:
+    - start_date: first day of the previous month
+    - end_date: logical_date
+
+    :return: Tuple containing (start_date, end_date) in YYYY-MM-DD format.
+    :raises AirflowFailException: If only one date is provided, or if start_date is after end_date.
     """
     ctx = get_current_context()
     start_date = (ctx.get("params") or {}).get("start_date")
     end_date = (ctx.get("params") or {}).get("end_date")
 
-    if not start_date or not end_date:
-        raise AirflowFailException("Need to specify both start_date and end_date (YYYY-MM-DD).")
+    if start_date and end_date:
+        if start_date > end_date:
+            raise AirflowFailException("start_date must not be after end_date.")
+        return start_date, end_date
 
-    if start_date > end_date:
-        raise AirflowFailException("start_date must not be after end_date.")
+    if start_date or end_date:
+        raise AirflowFailException("Either provide both start_date and end_date, or leave both empty for automatic calculation.")
 
-    return start_date, end_date
+    logical_date = ctx["logical_date"].in_timezone(ctx["dag"].timezone).date()
+    start = logical_date.replace(day=1) - relativedelta(months=1)
+    end = logical_date
+    return start.isoformat(), end.isoformat()
 
 
 def process_modregning() -> None:
@@ -71,7 +81,7 @@ def process_modregning() -> None:
     uid, attachment_name, excel_bytes = found
     logger.info(f"Found Excel attachment in email UID {uid.decode()}: {attachment_name} ({len(excel_bytes)} bytes)")
 
-    start_date, end_date = _resolve_month_interval()
+    start_date, end_date = _resolve_date_range()
     logger.info(f"Modregning date range: {start_date} -> {end_date}")
 
     try:

--- a/dags/dag_modregning/process_modregning.py
+++ b/dags/dag_modregning/process_modregning.py
@@ -136,9 +136,9 @@ def process_modregning() -> None:
 
         logger.info("Modregning processing completed successfully (email sent).")
 
+    except Exception as e:
+        raise AirflowFailException("Error processing Modregning") from e
+    finally:
         # Delete the input email right after successful processing (report sent)
         email_reader.delete_email_by_uid(uid=uid, mailbox="INBOX", expunge=True)
         logger.info(f"Deleted input email {attachment_name} with UID {uid!r} from INBOX")
-
-    except Exception as e:
-        raise AirflowFailException("Error processing Modregning") from e

--- a/dags/dag_modregning/process_modregning.py
+++ b/dags/dag_modregning/process_modregning.py
@@ -127,7 +127,7 @@ def process_modregning() -> None:
             sender=sender,
             recipients=recipients,
             subject=f"Modregninger for {report_date}",
-            body=f"Liste af Modregning er vedhæftet: {report_date}",
+            body=f"Liste af Modregning er vedhæftet: fra {report_date} med Startdato {start_dato} og Slutdato {slut_dato}",
             attachments=[(filename, excel_bytes)],
         )
 

--- a/dags/dag_modregning/process_modregning.py
+++ b/dags/dag_modregning/process_modregning.py
@@ -22,20 +22,20 @@ def _resolve_month_interval() -> tuple[str, str]:
     """
     Resolve and validate month interval from DAG runtime params.
 
-    :return: Tuple containing (start_dato, slut_dato).
+    :return: Tuple containing (start_date, end_date).
     :raises AirflowFailException: If required params are missing or the interval is invalid.
     """
     ctx = get_current_context()
-    start_dato = (ctx.get("params") or {}).get("start_dato")
-    slut_dato = (ctx.get("params") or {}).get("slut_dato")
+    start_date = (ctx.get("params") or {}).get("start_date")
+    end_date = (ctx.get("params") or {}).get("end_date")
 
-    if not start_dato or not slut_dato:
-        raise AirflowFailException("Need to specify both start_dato and slut_dato (YYYY-MM-DD).")
+    if not start_date or not end_date:
+        raise AirflowFailException("Need to specify both start_date and end_date (YYYY-MM-DD).")
 
-    if start_dato > slut_dato:
-        raise AirflowFailException("start_dato must not be after slut_dato.")
+    if start_date > end_date:
+        raise AirflowFailException("start_date must not be after end_date.")
 
-    return start_dato, slut_dato
+    return start_date, end_date
 
 
 def process_modregning() -> None:
@@ -71,8 +71,8 @@ def process_modregning() -> None:
     uid, attachment_name, excel_bytes = found
     logger.info(f"Found Excel attachment in email UID {uid.decode()}: {attachment_name} ({len(excel_bytes)} bytes)")
 
-    start_dato, slut_dato = _resolve_month_interval()
-    logger.info(f"Modregning date range: {start_dato} -> {slut_dato}")
+    start_date, end_date = _resolve_month_interval()
+    logger.info(f"Modregning date range: {start_date} -> {end_date}")
 
     try:
         df = pd.read_excel(
@@ -98,7 +98,7 @@ def process_modregning() -> None:
             ydelse_client = YdelseListeHentClient(client_certificate_file_path=client_cert_path)
             for cpr in cpr_list:
                 try:
-                    payload = ydelse_client.effektuering_hent(cpr=cpr, start_dato=start_dato, slut_dato=slut_dato)
+                    payload = ydelse_client.effektuering_hent(cpr=cpr, start_dato=start_date, slut_dato=end_date)
 
                     ydelser, found_any = extract_ydelser_from_serviceplatform_response(payload=payload)
 
@@ -130,7 +130,7 @@ def process_modregning() -> None:
             sender=sender,
             recipients=recipients,
             subject=f"Modregninger for {report_date}",
-            body=f"Liste af Modregning er vedhæftet: fra {report_date} med Startdato {start_dato} og Slutdato {slut_dato}",
+            body=f"Liste af Modregning er vedhæftet: fra {report_date} med Startdato {start_date} og Slutdato {end_date}",
             attachments=[(filename, excel_bytes)],
         )
 

--- a/dags/dag_modregning/process_modregning.py
+++ b/dags/dag_modregning/process_modregning.py
@@ -18,21 +18,24 @@ from dag_modregning.modregning_data import (
 logger = logging.getLogger(__name__)
 
 
-def _resolve_date_range() -> tuple[str, str]:
+def _resolve_month_interval() -> tuple[str, str]:
     """
-    Resolve start_dato/slut_dato as ISO dates (YYYY-MM-DD) based on Airflow `logical_date`.
+    Resolve and validate month interval from DAG runtime params.
 
-    - `logical_date` is converted to the DAG timezone and truncated to a date.
-    - `start_dato` is set to the 1st day of the previous month relative to `logical_date`.
-    - `slut_dato` is set to `logical_date`.
-
-    :return: (start_dato, slut_dato) as ISO date strings.
+    :return: Tuple containing (start_dato, slut_dato).
+    :raises AirflowFailException: If required params are missing or the interval is invalid.
     """
     ctx = get_current_context()
-    logical_date = ctx["logical_date"].in_timezone(ctx["dag"].timezone).date()
-    start = logical_date.replace(day=1) - relativedelta(months=1)
-    end = logical_date
-    return start.isoformat(), end.isoformat()
+    start_dato = (ctx.get("params") or {}).get("start_dato")
+    slut_dato = (ctx.get("params") or {}).get("slut_dato")
+
+    if not start_dato or not slut_dato:
+        raise AirflowFailException("Need to specify both start_dato and slut_dato (YYYY-MM-DD).")
+
+    if start_dato > slut_dato:
+        raise AirflowFailException("start_dato must not be after slut_dato.")
+
+    return start_dato, slut_dato
 
 
 def process_modregning() -> None:
@@ -68,7 +71,7 @@ def process_modregning() -> None:
     uid, attachment_name, excel_bytes = found
     logger.info(f"Found Excel attachment in email UID {uid.decode()}: {attachment_name} ({len(excel_bytes)} bytes)")
 
-    start_dato, slut_dato = _resolve_date_range()
+    start_dato, slut_dato = _resolve_month_interval()
     logger.info(f"Modregning date range: {start_dato} -> {slut_dato}")
 
     try:

--- a/docs/modregning.md
+++ b/docs/modregning.md
@@ -10,9 +10,10 @@ Formålet med jobbet er at understøtte Betalingskontorets behov for at sammenho
 
 Koden består af et DAG-job, der udfører følgende trin:
 
-- Beregner dato-interval ud fra Airflow `logical_date`:
-  - `start_dato`: 1. dag i forrige måned
-  - `slut_dato`: `logical_date` (dagens dato i DAG’ens timezone)
+- Læser `start_date` og `end_date` fra DAG params (valgfrie)
+- Hvis begge datoer er angivet ved trigger:
+  - `start_date` og `end_date` bruges direkte (format YYYY-MM-DD)
+  - Jobbet validerer at `start_date` ikke er efter `end_date`
 - Finder nyeste Excel-vedhæftning i en IMAP Modregning-postkassen (default `INBOX`)
   - Email hentes via IMAP (EmailReader)
   - Jobbet scanner de seneste emails (nyeste først) og leder efter en `.xlsx`-vedhæftning, hvor filnavnet starter med et af de konfigurerede prefixes (fx `Modregning`)
@@ -23,7 +24,7 @@ Koden består af et DAG-job, der udfører følgende trin:
   - Hvis der ingen ydelser findes i svaret sættes feltet til `Ingen Ydelse`
 - Bygger en Excel-rapport (in-memory) med kolonnerne `cpr` og `YdelseNavn`
 - Sender rapporten som vedhæftet fil via SMTP (filnavn: `Modregning_YYYY-MM-DD.xlsx`)
-- Sletter input-emailen fra Modregning-postkassen efter vellykket gennemførsel (rapport sendt)
+- Sletter input-emailen fra Modregning-postkassen uanset vellykket gennemførsel eller hvis der er en fejl i Excel-arket.
   - Emailen slettes via UID i `INBOX` og expunges med det samme. Det vil sige at input mailen hverken kan findes under
   `INBOX` eller `Deleted Items`. Den bliver slettet permanent.
 
@@ -35,9 +36,9 @@ Koden består af et DAG-job, der udfører følgende trin:
 
 **Forudsætning(manuel proces):**
 
-Den 15. i hver måned sender Betalingskontoret en ny CPR-liste (Excel) til Modregning Postkassen. CPR-listen bruges som input til modregningsopslag.
+Betalingskontoret en ny CPR-liste sender (Excel) til Modregning Postkassen. CPR-listen bruges som input til modregningsopslag.
 Excel-filen skal indeholde kolonnen `ID-nummer` (CPR). 
-Jobbet bruger den nyeste matchende vedhæftning i postkassen, hvis der ikke ligger en relevant mail med vedhæftet Excel, kan jobbet ikke gennemføre rapporten som forventet. Betalingskontoret vedligeholder desuden listen `modregning_excluded_ydelse_list` (tilføj/fjern ydelser efter behov).
+Jobbet bruger den nyeste matchende vedhæftning i postkassen, hvis der ikke ligger en relevant mail med vedhæftet Excel, kan jobbet ikke gennemføre rapporten som forventet. Betalingskontoret vedligeholder desuden listen `modregning_excluded_ydelse_list` (tilføj/fjern ydelser efter behov). Brugeren, der trigger DAG'en/jobbet skal angive både `start_date` og `end_date`.
 
 ## Afhængigheder
 
@@ -98,4 +99,11 @@ Eksempel:
 
 ## Schedule
 
-Betalingskontoret har adgang til UI'en i Airflow med rollen: `Modregning` hvor de kun kan se det DAG som tilhører Modregning. Her kan de selv trigger DAG'et efter eget behov.
+Betalingskontoret har adgang til UI'en i Airflow med rollen: `Modregning` hvor de kun kan se det DAG som tilhører Modregning. Her kan de selv trigger DAG'et efter eget behov. Når man trigger jobbet skal man angive følgende parameter:
+
+- `start_date`: `YYYY-MM-DD`
+- `end_date`: `YYYY-MM-DD`
+
+Eksempel:
+- `start_date`: `2026-06-01`
+- `end_date`: `2026-07-27`

--- a/docs/modregning.md
+++ b/docs/modregning.md
@@ -14,6 +14,11 @@ Koden består af et DAG-job, der udfører følgende trin:
 - Hvis begge datoer er angivet ved trigger:
   - `start_date` og `end_date` bruges direkte (format YYYY-MM-DD)
   - Jobbet validerer at `start_date` ikke er efter `end_date`
+- Hvis ingen datoer er angivet ved trigger:
+  - `start_date` beregnes automatisk som første dag i forrige måned (ud fra logical_date i DAG timezone)
+  - `end_date` sættes automatisk til logical_date (i DAG timezone)
+- Hvis kun én af datoerne er angivet:
+  - Jobbet fejler med valideringsfejl (begge datoer skal angives sammen, eller begge udelades)
 - Finder nyeste Excel-vedhæftning i en IMAP Modregning-postkassen (default `INBOX`)
   - Email hentes via IMAP (EmailReader)
   - Jobbet scanner de seneste emails (nyeste først) og leder efter en `.xlsx`-vedhæftning, hvor filnavnet starter med et af de konfigurerede prefixes (fx `Modregning`)
@@ -24,7 +29,7 @@ Koden består af et DAG-job, der udfører følgende trin:
   - Hvis der ingen ydelser findes i svaret sættes feltet til `Ingen Ydelse`
 - Bygger en Excel-rapport (in-memory) med kolonnerne `cpr` og `YdelseNavn`
 - Sender rapporten som vedhæftet fil via SMTP (filnavn: `Modregning_YYYY-MM-DD.xlsx`)
-- Sletter input-emailen fra Modregning-postkassen uanset vellykket gennemførsel eller hvis der er en fejl i Excel-arket.
+- Sletter input-emailen fra Modregning-postkassen uanset vellykket gennemførsel eller hvis der er en fejl i Excel-arket(Mangler `ID-nummer`).
   - Emailen slettes via UID i `INBOX` og expunges med det samme. Det vil sige at input mailen hverken kan findes under
   `INBOX` eller `Deleted Items`. Den bliver slettet permanent.
 
@@ -38,7 +43,11 @@ Koden består af et DAG-job, der udfører følgende trin:
 
 Betalingskontoret en ny CPR-liste sender (Excel) til Modregning Postkassen. CPR-listen bruges som input til modregningsopslag.
 Excel-filen skal indeholde kolonnen `ID-nummer` (CPR). 
-Jobbet bruger den nyeste matchende vedhæftning i postkassen, hvis der ikke ligger en relevant mail med vedhæftet Excel, kan jobbet ikke gennemføre rapporten som forventet. Betalingskontoret vedligeholder desuden listen `modregning_excluded_ydelse_list` (tilføj/fjern ydelser efter behov). Brugeren, der trigger DAG'en/jobbet skal angive både `start_date` og `end_date`.
+Jobbet bruger den nyeste matchende vedhæftning i postkassen, hvis der ikke ligger en relevant mail med vedhæftet Excel, kan jobbet ikke gennemføre rapporten som forventet. Betalingskontoret vedligeholder desuden listen `modregning_excluded_ydelse_list` (tilføj/fjern ydelser efter behov). 
+
+- Brugeren, der trigger DAG'en/jobbet, kan vælge enten:
+  - Angive både `start_date` og `end_date` manuelt
+  - Lade begge felter være tomme, så dato-intervallet beregnes automatisk
 
 ## Afhængigheder
 
@@ -99,7 +108,9 @@ Eksempel:
 
 ## Schedule
 
-Betalingskontoret har adgang til UI'en i Airflow med rollen: `Modregning` hvor de kun kan se det DAG som tilhører Modregning. Her kan de selv trigger DAG'et efter eget behov. Når man trigger jobbet skal man angive følgende parameter:
+Betalingskontoret har adgang til UI'en i Airflow med rollen: `Modregning` hvor de kun kan se det DAG som tilhører Modregning. Her kan de selv trigger DAG'et efter eget behov. Når man trigger jobbet, er dato-parametre valgfrie.
+
+Mulighed 1 (manuel periode):
 
 - `start_date`: `YYYY-MM-DD`
 - `end_date`: `YYYY-MM-DD`
@@ -107,3 +118,14 @@ Betalingskontoret har adgang til UI'en i Airflow med rollen: `Modregning` hvor d
 Eksempel:
 - `start_date`: `2026-06-01`
 - `end_date`: `2026-07-27`
+
+
+Mulighed 2 (automatisk periode):
+
+- `start_date`: `tom`
+- `end_date`: `tom`
+
+
+Automatisk beregning:
+- `start_date` = første dag i forrige måned (relativt til logical_date)
+- `end_date` = logical_date


### PR DESCRIPTION
Change default_var to a dictionary for proper deserialization.

Måske du også kunne rykke det ind i en funktion?
```
def some_function():
  excluded_cfg = Variable.get(
      "modregning_excluded_ydelse_list",
      default_var={"excluded_ydelse_name": []},
      excluded_cfg.get("excluded_ydelse_name", [])
      deserialize_json=True,
  )
  
  # Burde det ikke være 'excluded_ydelse_names' ? det er et sæt, ikke?
  excluded_ydelse_name = {
      x.strip()
      for x in excluded_cfg.get("excluded_ydelse_name", [])
      if x and isinstance(x, str)
  }
  return excluded_ydelse_name 
```