### PR TITLE
Job/arbejdsfortjeneste suggestions

### DIFF
--- a/dags/dag_arbejdsfortjeneste/arbejdsfortjeneste_data.py
+++ b/dags/dag_arbejdsfortjeneste/arbejdsfortjeneste_data.py
@@ -68,7 +68,7 @@ def map_indkomsttype(value: str | int | None) -> str | None:
     """
     Map an IndkomstType code to a configured label.
 
-    :param value: Raw income type code from Seviceplatform SKAT payload.
+    :param value: Raw income type code from Serviceplatform SKAT payload.
     :return: Mapped label if configured
     """
     if value is None:
@@ -91,7 +91,7 @@ def _normalize_cpr(value: object) -> str | None:
 
 def extract_cprs(
     df: pd.DataFrame,
-    column: str = "Cprnr.",
+    column: str = None,
 ) -> list[str]:
     """
     Extract CPR numbers from a DataFrame column without deduplicating.
@@ -100,6 +100,9 @@ def extract_cprs(
     :param column: Column name containing CPR numbers.
     :return: CPR list
     """
+    if column is None:
+        raise ValueError("Column name must be provided for CPR extraction")
+
     cprs = [
         cpr
         for cpr in df[column].map(_normalize_cpr).tolist()

--- a/dags/dag_arbejdsfortjeneste/arbejdsfortjeneste_data.py
+++ b/dags/dag_arbejdsfortjeneste/arbejdsfortjeneste_data.py
@@ -91,7 +91,7 @@ def _normalize_cpr(value: object) -> str | None:
 
 def extract_cprs(
     df: pd.DataFrame,
-    column: str = None,
+    column: str | None = None,
 ) -> list[str]:
     """
     Extract CPR numbers from a DataFrame column without deduplicating.

--- a/dags/dag_arbejdsfortjeneste/dag_arbejdsfortjeneste.py
+++ b/dags/dag_arbejdsfortjeneste/dag_arbejdsfortjeneste.py
@@ -7,7 +7,7 @@ from utils.config import DEFAULT_DAG_ARGS
 from dag_arbejdsfortjeneste.process_arbejdsfortjeneste import process_arbejdsfortjeneste
 
 dag_args = DEFAULT_DAG_ARGS.copy()
-dag_args["retries"] = 1
+dag_args["retries"] = 0
 
 
 with DAG(

--- a/dags/dag_arbejdsfortjeneste/process_arbejdsfortjeneste.py
+++ b/dags/dag_arbejdsfortjeneste/process_arbejdsfortjeneste.py
@@ -45,7 +45,7 @@ def process_arbejdsfortjeneste() -> None:
      Process Arbejdsfortjeneste CPR input and deliver an income change report.
 
     :return: None.
-    :raises AirflowFailException: If required input is missing or report processing fails.
+    :raises AirflowFailException: If required config or CPR input is missing, or if report processing fails.
     """
     logger.info("Starting to process arbejdsfortjeneste data...")
 
@@ -57,12 +57,21 @@ def process_arbejdsfortjeneste() -> None:
     abonnent_type_kode = skat_client_config["abonnent_type_kode"]
     adgang_formaal_type_kode = skat_client_config["adgang_formaal_type_kode"]
 
+    if not all((virksomhed_se_nummer_identifikator, abonnement_type_kode, abonnent_type_kode, adgang_formaal_type_kode)):
+        raise AirflowFailException("SKAT client configuration is not set properly.")
+
     sender = arbejdsfortjeneste_runtime_config["sender_email"]
     recipients = arbejdsfortjeneste_runtime_config["recipient_emails"]
     smtp_server = arbejdsfortjeneste_runtime_config["smtp_server"]
     imap_server = arbejdsfortjeneste_runtime_config["imap_server"]
 
+    if not all((sender, recipients, smtp_server)):
+        raise AirflowFailException("SMTP configuration is not set properly.")
+
     arbejdsfortjeneste_imap_conn = BaseHook.get_connection("arbejdsfortjeneste_imap")
+
+    if not all((arbejdsfortjeneste_imap_conn.login, arbejdsfortjeneste_imap_conn.password, imap_server)):
+        raise AirflowFailException("IMAP configuration is not set properly.")
 
     email_reader = EmailReader(
         email=arbejdsfortjeneste_imap_conn.login,

--- a/dags/dag_arbejdsfortjeneste/process_arbejdsfortjeneste.py
+++ b/dags/dag_arbejdsfortjeneste/process_arbejdsfortjeneste.py
@@ -281,9 +281,9 @@ def process_arbejdsfortjeneste() -> None:
 
         logger.info("Arbejdsfortjeneste processing completed successfully (email sent).")
 
-        # Delete the processed input email after sending the report
-        email_reader.delete_email_by_uid(uid=uid, mailbox="INBOX", expunge=True)
-        logger.info(f"Deleted Arbejdsfortjeneste input email {filename} with UID {uid!r} from INBOX")
-
     except Exception as e:
         raise AirflowFailException("Failed to process arbejdsfortjeneste report") from e
+    finally:
+        # Delete the processed input email no matter what
+        email_reader.delete_email_by_uid(uid=uid, mailbox="INBOX", expunge=True)
+        logger.info(f"Deleted Arbejdsfortjeneste input email {filename} with UID {uid!r} from INBOX")

--- a/dags/dag_arbejdsfortjeneste/process_arbejdsfortjeneste.py
+++ b/dags/dag_arbejdsfortjeneste/process_arbejdsfortjeneste.py
@@ -1,4 +1,5 @@
 import logging
+import re
 import pandas as pd
 import io
 from airflow.models import Variable
@@ -45,6 +46,13 @@ def _resolve_month_interval() -> tuple[str, str]:
     if not start_month or not end_month:
         raise AirflowFailException("Need to specify both start_month and end_month (YYYYMM).")
 
+    start_month = str(start_month).strip()
+    end_month = str(end_month).strip()
+
+    regex_pattern = r"^\d{4}(?:0[1-9]|1[0-2])$"
+    if not (re.fullmatch(regex_pattern, start_month) and re.fullmatch(regex_pattern, end_month)):
+        raise AirflowFailException("start_month and end_month must be in YYYYMM format.")
+
     if start_month > end_month:
         raise AirflowFailException("start_month must not be after end_month.")
 
@@ -60,6 +68,7 @@ def process_arbejdsfortjeneste() -> None:
     """
     logger.info("Starting to process arbejdsfortjeneste data...")
 
+    # Get and validate runtime configurations from Airflow Variables
     skat_client_config = Variable.get("skat_client_config", deserialize_json=True)
     arbejdsfortjeneste_runtime_config = Variable.get("arbejdsfortjeneste_runtime_config", deserialize_json=True)
 
@@ -106,6 +115,7 @@ def process_arbejdsfortjeneste() -> None:
     smtp_server = arbejdsfortjeneste_runtime_config.get("smtp_server")
     imap_server = arbejdsfortjeneste_runtime_config.get("imap_server")
 
+    # Read mailbox username and password from the Airflow connection (host lives in the runtime config)
     arbejdsfortjeneste_imap_conn = BaseHook.get_connection("arbejdsfortjeneste_imap")
 
     if not all((arbejdsfortjeneste_imap_conn.login, arbejdsfortjeneste_imap_conn.password, imap_server)):
@@ -117,6 +127,7 @@ def process_arbejdsfortjeneste() -> None:
         imap_server=imap_server,
     )
 
+    # Find the newest matching Excel attachment in the mailbox
     found = find_latest_attachment(
         email_reader=email_reader
     )
@@ -128,14 +139,16 @@ def process_arbejdsfortjeneste() -> None:
     logger.info(f"Found attachment: {filename} (UID: {uid.decode()}) with size {len(content_bytes)} bytes")
 
     try:
+        # Expected input file format: an Excel sheet where CPR numbers are in the "Cprnr." column
+        cpr_col_name = "Cprnr."
         df = pd.read_excel(
             io.BytesIO(content_bytes),
             engine="openpyxl",
-            dtype={"Cprnr.": str},
+            dtype={cpr_col_name: str},
             sheet_name=0,
         )
 
-        cpr_list = extract_cprs(df=df)
+        cpr_list = extract_cprs(df=df, column=cpr_col_name)
         if not cpr_list:
             raise AirflowFailException("No CPR values found in the Excel file")
 
@@ -144,6 +157,8 @@ def process_arbejdsfortjeneste() -> None:
 
         logger.info(f"Arbejdsfortjeneste date range: {start_month} -> {end_month} (months: {', '.join(months)})")
 
+        # Get columns from the report and map them to the corresponding blanket field IDs
+        # This ensures that the report includes all relevant fields and that they are correctly labeled
         field_map = get_report_field_to_blanket_field_id()
         report_fields = tuple(field_map.keys())
 
@@ -155,6 +170,7 @@ def process_arbejdsfortjeneste() -> None:
             *report_fields,
         ]
 
+        # If a lookup fails, add an empty row so the CPR still appears in the report
         def _placeholder_row(for_cpr: str) -> dict:
             return {
                 "cpr": for_cpr,
@@ -170,6 +186,7 @@ def process_arbejdsfortjeneste() -> None:
         from utils.kombit import TempClientCert
         from kombit_client.integrations.sf0770a import SKATForwardEIndkomstClient  # Import lazily to avoid Airflow freezing issue
 
+        # Create a temporary client certificate file for Serviceplatform calls
         with TempClientCert() as client_cert_path:
             skat_client = SKATForwardEIndkomstClient(
                 virksomhed_se_nummer_identifikator=virksomhed_se_nummer_identifikator,
@@ -184,6 +201,7 @@ def process_arbejdsfortjeneste() -> None:
                 logger.info(f"Processing CPR {idx + 1}/{total_cprs}")
 
                 try:
+                    # Fetch data for the full month range for the Indkomstoplysninger sheet
                     range_payload = skat_client.indkomstoplysninger_laes(
                         person_civil_registration_identifier=cpr,
                         soege_aar_maaned_fra_kode=start_month,
@@ -195,10 +213,14 @@ def process_arbejdsfortjeneste() -> None:
                     logger.error(f"Failed range fetch for CPR {idx + 1}/{total_cprs}: {e}")
                     rows_range = [_placeholder_row(for_cpr=cpr)]
 
+                # Add the full-range income rows to the main list for the Indkomstoplysninger sheet
                 all_indkomst_rows.extend(rows_range)
+
+                # Add an empty separator row between CPR groups in the Excel output
                 if idx != total_cprs - 1:
                     all_indkomst_rows.append({col: None for col in base_cols})
 
+                # Fetch each month separately so we can compare one month to the next
                 rows_by_month: dict[str, list[dict]] = {}
                 for month in months:
                     try:
@@ -213,6 +235,7 @@ def process_arbejdsfortjeneste() -> None:
                         logger.error(f"Failed month fetch for CPR {idx + 1}/{total_cprs} ({month}): {e}")
                         rows_by_month[month] = [_placeholder_row(for_cpr=cpr)]
 
+                # Compare each month with the previous month and collect the differences
                 for month_idx in range(1, len(months)):
                     prev_month = months[month_idx - 1]
                     curr_month = months[month_idx]
@@ -221,8 +244,10 @@ def process_arbejdsfortjeneste() -> None:
                     df_curr = pd.DataFrame(rows_by_month[curr_month], columns=base_cols)
                     all_diff.append(build_diff_table(df_prev=df_prev, df_curr=df_curr, prev_month=prev_month, curr_month=curr_month))
 
+        # Create a DataFrame for full-range income rows
         indkomst_df = pd.DataFrame(all_indkomst_rows, columns=base_cols)
 
+        # Create a DataFrame for month-to-month differences, or an empty DataFrame if no differences were found
         diff_cols = [
             "FraMåned",
             "TilMåned",
@@ -242,6 +267,7 @@ def process_arbejdsfortjeneste() -> None:
         dag_tz = ctx["dag"].timezone
         report_date = logical_date.in_timezone(dag_tz).date().isoformat()
 
+        # Build the report filename from the selected month range and run date
         report_filename = f"Arbejdsfortjeneste_{start_month}_til_{end_month}_{report_date}.xlsx"
 
         email_sender = EmailSender(smtp_server=smtp_server)
@@ -255,6 +281,7 @@ def process_arbejdsfortjeneste() -> None:
 
         logger.info("Arbejdsfortjeneste processing completed successfully (email sent).")
 
+        # Delete the processed input email after sending the report
         email_reader.delete_email_by_uid(uid=uid, mailbox="INBOX", expunge=True)
         logger.info(f"Deleted Arbejdsfortjeneste input email {filename} with UID {uid!r} from INBOX")
 

--- a/dags/dag_arbejdsfortjeneste/process_arbejdsfortjeneste.py
+++ b/dags/dag_arbejdsfortjeneste/process_arbejdsfortjeneste.py
@@ -20,6 +20,17 @@ from dag_arbejdsfortjeneste.arbejdsfortjeneste_data import (
 logger = logging.getLogger(__name__)
 
 
+def _get_missing_or_empty_keys(config: dict, required_keys: tuple[str, ...]) -> list[str]:
+    """
+    Return required keys that are missing or have an empty value.
+
+    :param config: Configuration dictionary to validate.
+    :param required_keys: Keys that must be present and non-empty.
+    :return: Missing/empty key names.
+    """
+    return [key for key in required_keys if not config.get(key)]
+
+
 def _resolve_month_interval() -> tuple[str, str]:
     """
     Resolve and validate month interval from DAG runtime params.
@@ -52,21 +63,48 @@ def process_arbejdsfortjeneste() -> None:
     skat_client_config = Variable.get("skat_client_config", deserialize_json=True)
     arbejdsfortjeneste_runtime_config = Variable.get("arbejdsfortjeneste_runtime_config", deserialize_json=True)
 
-    virksomhed_se_nummer_identifikator = skat_client_config["virksomhed_se_nummer_identifikator"]
-    abonnement_type_kode = skat_client_config["abonnement_type_kode"]
-    abonnent_type_kode = skat_client_config["abonnent_type_kode"]
-    adgang_formaal_type_kode = skat_client_config["adgang_formaal_type_kode"]
+    if not isinstance(skat_client_config, dict):
+        raise AirflowFailException("SKAT client configuration must be a JSON object.")
 
-    if not all((virksomhed_se_nummer_identifikator, abonnement_type_kode, abonnent_type_kode, adgang_formaal_type_kode)):
-        raise AirflowFailException("SKAT client configuration is not set properly.")
+    skat_required_keys = (
+        "virksomhed_se_nummer_identifikator",
+        "abonnement_type_kode",
+        "abonnent_type_kode",
+        "adgang_formaal_type_kode",
+    )
+    missing_skat_keys = _get_missing_or_empty_keys(config=skat_client_config, required_keys=skat_required_keys)
+    if missing_skat_keys:
+        raise AirflowFailException(
+            f"SKAT client configuration is missing required keys: {', '.join(missing_skat_keys)}"
+        )
 
-    sender = arbejdsfortjeneste_runtime_config["sender_email"]
-    recipients = arbejdsfortjeneste_runtime_config["recipient_emails"]
-    smtp_server = arbejdsfortjeneste_runtime_config["smtp_server"]
-    imap_server = arbejdsfortjeneste_runtime_config["imap_server"]
+    virksomhed_se_nummer_identifikator = skat_client_config.get("virksomhed_se_nummer_identifikator")
+    abonnement_type_kode = skat_client_config.get("abonnement_type_kode")
+    abonnent_type_kode = skat_client_config.get("abonnent_type_kode")
+    adgang_formaal_type_kode = skat_client_config.get("adgang_formaal_type_kode")
 
-    if not all((sender, recipients, smtp_server)):
-        raise AirflowFailException("SMTP configuration is not set properly.")
+    if not isinstance(arbejdsfortjeneste_runtime_config, dict):
+        raise AirflowFailException("Arbejdsfortjeneste runtime configuration must be a JSON object.")
+
+    runtime_required_keys = (
+        "sender_email",
+        "recipient_emails",
+        "smtp_server",
+        "imap_server",
+    )
+    missing_runtime_keys = _get_missing_or_empty_keys(
+        config=arbejdsfortjeneste_runtime_config,
+        required_keys=runtime_required_keys,
+    )
+    if missing_runtime_keys:
+        raise AirflowFailException(
+            f"Arbejdsfortjeneste runtime configuration is missing required keys: {', '.join(missing_runtime_keys)}"
+        )
+
+    sender = arbejdsfortjeneste_runtime_config.get("sender_email")
+    recipients = arbejdsfortjeneste_runtime_config.get("recipient_emails")
+    smtp_server = arbejdsfortjeneste_runtime_config.get("smtp_server")
+    imap_server = arbejdsfortjeneste_runtime_config.get("imap_server")
 
     arbejdsfortjeneste_imap_conn = BaseHook.get_connection("arbejdsfortjeneste_imap")
 
@@ -102,16 +140,19 @@ def process_arbejdsfortjeneste() -> None:
             raise AirflowFailException("No CPR values found in the Excel file")
 
         start_month, end_month = _resolve_month_interval()
-        months = iter_months(start_yyyymm=start_month, end_yyyymm=end_month)
+        months = list(iter_months(start_yyyymm=start_month, end_yyyymm=end_month))
 
         logger.info(f"Arbejdsfortjeneste date range: {start_month} -> {end_month} (months: {', '.join(months)})")
+
+        field_map = get_report_field_to_blanket_field_id()
+        report_fields = tuple(field_map.keys())
 
         base_cols = [
             "cpr",
             "VirksomhedSENummerIdentifikator",
             "IndkomstPersonGruppeDispositionDato",
             "AngivelsePeriode",
-            *get_report_field_to_blanket_field_id().keys(),
+            *report_fields,
         ]
 
         def _placeholder_row(for_cpr: str) -> dict:
@@ -120,7 +161,7 @@ def process_arbejdsfortjeneste() -> None:
                 "VirksomhedSENummerIdentifikator": None,
                 "IndkomstPersonGruppeDispositionDato": None,
                 "AngivelsePeriode": None,
-                **{k: None for k in get_report_field_to_blanket_field_id().keys()},
+                **{k: None for k in report_fields},
             }
 
         all_diff: list[pd.DataFrame] = []

--- a/docs/arbejdsfortjeneste.md
+++ b/docs/arbejdsfortjeneste.md
@@ -3,7 +3,7 @@
 
 ## Formål
 
-Formålet med jobbet er at understøtte kontrollen af personer, der er tildelt tabt arbejdsfortjeneste, ved at identificere ændringer i deres indkomst. Jobbet læser den nyeste relevante CPR-liste fra Arbejdsfortjenestse -  Postkassen, henter indkomstoplysninger via Serviceplatformen (SKAT Forward eIndkomst, [SF0770A](https://digitaliseringskataloget.dk/integration/sf0770a)) og sender en rapport til Familie- og rådgivningscenter.
+Formålet med jobbet er at understøtte kontrollen af personer, der er tildelt tabt arbejdsfortjeneste, ved at identificere ændringer i deres indkomst. Jobbet læser den nyeste relevante CPR-liste fra Arbejdsfortjeneste - Postkassen, henter indkomstoplysninger via Serviceplatformen (SKAT Forward eIndkomst, [SF0770A](https://digitaliseringskataloget.dk/integration/sf0770a)) og sender en rapport til Familie- og rådgivningscenter.
 
 ## Beskrivelse
 

--- a/docs/arbejdsfortjeneste.md
+++ b/docs/arbejdsfortjeneste.md
@@ -3,7 +3,7 @@
 
 ## Formål
 
-Formålet med jobbet er at understøtte kontrollen af personer, der er tildelt tabt arbejdsfortjeneste, ved at identificere ændringer i deres indkomst. Jobbet læser den nyeste relevante CPR-liste fra Arbejdsfortjenetse -  Postkassen, henter indkomstoplysninger via Serviceplatformen (SKAT Forward eIndkomst, SF0770A) og sender en rapport til Familie- og rådgivningscenter
+Formålet med jobbet er at understøtte kontrollen af personer, der er tildelt tabt arbejdsfortjeneste, ved at identificere ændringer i deres indkomst. Jobbet læser den nyeste relevante CPR-liste fra Arbejdsfortjenestse -  Postkassen, henter indkomstoplysninger via Serviceplatformen (SKAT Forward eIndkomst, [SF0770A](https://digitaliseringskataloget.dk/integration/sf0770a)) og sender en rapport til Familie- og rådgivningscenter.
 
 ## Beskrivelse
 
@@ -34,11 +34,11 @@ Koden består af et DAG-job, der udfører følgende trin:
 	- `Indkomstoplysninger`
 	- `Ændring` (kun rækker med ændring forskellig fra 0)
 - Sender rapporten som vedhæftet fil via SMTP.
-- Filnavn foelger formatet:
-	- `Arbejdsfortjeneste_STARTMÅNED_til_SLUTMÅNED_YYYY-MM-DD.xlsx`
+- Filnavn følger formatet:
+	- `Arbejdsfortjeneste_<STARTMÅNED>_til_<SLUTMÅNED>_<YYYY-MM-DD>.xlsx`
 
 **Dataflow:**
-- Arbejdsfortjeneste Postkasse Email (Excel vedhæftning) -> CPR-liste -> Serviceplatform-opslag (SF0770A) -> Excel-rapport (Indkomstoplysninger + Ændring) -> Email til Familie- og rådgivningscenter
+- Arbejdsfortjeneste Postkasse Email (Excel vedhæftning) -> CPR-liste -> Serviceplatform-opslag ([SF0770A](https://digitaliseringskataloget.dk/integration/sf0770a)) -> Excel-rapport (Indkomstoplysninger + Ændring) -> Email til Familie- og rådgivningscenter
 
 Bemærk (datahåndtering):
 


### PR DESCRIPTION
Jeg har tilføjet en del validering af config vars etc., og skrevet nogle inline-kommentarer - tjek at mine kommentarer ikke er forkerte/misvisende, da du har bedre styr på flowet/businiss logic end mig. Du bør også lige teste, at den nye validering logik virker som forventet - jeg har ikke testet.

Og så har jeg et forslag til ændring af strukturen:
Overvej at opdele din "main" try-except block i flere dele -> alternativt opdele i flere airflow tasks.
Du kan f.eks. opdele i tasks som groft følger ETL-struktur:

1. Hent og valider config (E)
2. Hent data fra SKAT, mail etc. (E)
3. Transformer data, beregn ændringer og byg Excel-rapporten (T)
4. Send rapportmailen (L)
5. Slet den behandlede mail

Fordelen er, at vi kan retry præcis den del, der fejler. Hvis mail-sletning for eksempel fejler efter rapporten er sendt, kan vi nøjes med at retry cleanup-tasken i stedet for at køre hele flowet igen. Det er self. en større ændring, så det skal kun være hvis du synes det giver mening.

Beholder du jobbet som en enkelt task, bør du følge https://github.com/Randers-Kommune-Digitalisering/airflow/issues/98 - jeg har ikke tilføjet denne ændring. OBS. på at enhver fejl i din  "main" try-except block raiser en AirflowFailException som ikke trigger et retry. Et alternativ til at opdele i flere tasks kan være blot at opdele i flere try-except blocks som giver mulighed for at raise forskellige exceptions (giver mulighed for at trigger retry af hele flowet på specifikke fejl).