### PR TITLE
Add sorting option to mailbox cleaner configuration and update tests

### DIFF
--- a/dags/dag_mailbox_cleaner/config_validation.py
+++ b/dags/dag_mailbox_cleaner/config_validation.py
@@ -146,11 +146,15 @@ SCHEMA_REGISTRY: dict[str, dict[str, Any]] = {
     },
     "safety": {
         "required": [],
-        "optional": ["dry_run", "max_messages_per_run", "min_age_for_delete_days"],
+        "optional": ["dry_run", "max_messages_per_run", "min_age_for_delete_days", "sort"],
         "types": {
             "dry_run": "bool",
             "max_messages_per_run": "int",
             "min_age_for_delete_days": "int",
+            "sort": "str",
+        },
+        "enum": {
+            "sort": ["asc", "desc"],
         },
     },
 }

--- a/dags/dag_mailbox_cleaner/process_mailbox_cleaner.py
+++ b/dags/dag_mailbox_cleaner/process_mailbox_cleaner.py
@@ -36,7 +36,7 @@ def process_mailbox_cleaner(config: dict[str, Any] | None = None) -> None:
     safety = job_config.get("safety", {})
     action = job_config.get("action", {})
     dry_run = bool(safety.get("dry_run", True))
-    sort = str(safety.get("sort", "desc")).lower()
+    sort = str(safety.get("sort", "desc"))
     max_messages = safety.get("max_messages_per_run")
 
     if max_messages is not None:

--- a/dags/dag_mailbox_cleaner/process_mailbox_cleaner.py
+++ b/dags/dag_mailbox_cleaner/process_mailbox_cleaner.py
@@ -36,6 +36,7 @@ def process_mailbox_cleaner(config: dict[str, Any] | None = None) -> None:
     safety = job_config.get("safety", {})
     action = job_config.get("action", {})
     dry_run = bool(safety.get("dry_run", True))
+    sort = str(safety.get("sort", "desc")).lower()
     max_messages = safety.get("max_messages_per_run")
 
     if max_messages is not None:
@@ -77,7 +78,7 @@ def process_mailbox_cleaner(config: dict[str, Any] | None = None) -> None:
         candidate_uids = imap_client.search_uids(
             criteria=DEFAULT_SEARCH_CRITERIA,
             max_results=max_messages,
-            newest_first=True,
+            newest_first=(sort != "asc"),
         )
 
         logger.info(

--- a/docs/mailbox_cleaner.md
+++ b/docs/mailbox_cleaner.md
@@ -97,6 +97,9 @@ At least one requirement must be configured.
 
 - `safety.dry_run` (boolean, optional, default `true`): Log what would happen, but do not change emails.
 - `safety.max_messages_per_run` (int, optional): Hard cap per run.
+- `safety.sort` (string, optional, default `desc`): Candidate processing order when applying `max_messages_per_run`.
+  - `desc`: Newest-first (highest UID first).
+  - `asc`: Oldest-first (lowest UID first).
 - `safety.min_age_for_delete_days` (int, optional): Extra protection for delete action.
 
 ## Validation Rules
@@ -136,7 +139,8 @@ Use these rules when implementing validation:
   },
   "safety": {
     "dry_run": true,
-    "max_messages_per_run": 100
+    "max_messages_per_run": 100,
+    "sort": "desc"
   }
 }
 ```
@@ -181,6 +185,7 @@ Use these rules when implementing validation:
   "safety": {
     "dry_run": true,
     "max_messages_per_run": 200,
+    "sort": "desc",
     "min_age_for_delete_days": 14
   }
 }

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -130,11 +130,15 @@ except Exception:
 
 
 try:
-    from airflow.exceptions import AirflowFailException as _AirflowFailException  # noqa: F401
+    from airflow.exceptions import AirflowException as _AirflowException, AirflowFailException as _AirflowFailException  # noqa: F401
 except Exception:
     exceptions_mod = _ensure_module("airflow.exceptions")
+
+    class AirflowException(Exception):
+        pass
 
     class AirflowFailException(Exception):
         pass
 
+    exceptions_mod.AirflowException = AirflowException
     exceptions_mod.AirflowFailException = AirflowFailException

--- a/tests/dags/dag_fritidsjobs_webscraper/test_scapy_client.py
+++ b/tests/dags/dag_fritidsjobs_webscraper/test_scapy_client.py
@@ -102,3 +102,28 @@ def test_raise_for_crawl_errors_raises_on_non_playwright_downloader_exception() 
 
     with pytest.raises(RuntimeError, match="failed during crawl"):
         scrapy_client._raise_for_crawl_errors(stats)
+
+
+class _PlaywrightLikeError(Exception):
+    pass
+
+
+_PlaywrightLikeError.__module__ = "playwright._impl._errors"
+
+
+def test_is_retryable_playwright_navigation_error_accepts_http2_protocol_error() -> None:
+    error = _PlaywrightLikeError("Page.goto: net::ERR_HTTP2_PROTOCOL_ERROR at https://example.com")
+
+    assert scrapy_client._is_retryable_playwright_navigation_error(error) is True
+
+
+def test_is_retryable_playwright_navigation_error_rejects_non_playwright_errors() -> None:
+    error = RuntimeError("Page.goto: net::ERR_HTTP2_PROTOCOL_ERROR at https://example.com")
+
+    assert scrapy_client._is_retryable_playwright_navigation_error(error) is False
+
+
+def test_is_retryable_playwright_navigation_error_rejects_other_playwright_errors() -> None:
+    error = _PlaywrightLikeError("Page.goto: net::ERR_ABORTED at https://example.com")
+
+    assert scrapy_client._is_retryable_playwright_navigation_error(error) is False

--- a/tests/dags/dag_fritidsjobs_webscraper/test_scapy_client.py
+++ b/tests/dags/dag_fritidsjobs_webscraper/test_scapy_client.py
@@ -102,28 +102,3 @@ def test_raise_for_crawl_errors_raises_on_non_playwright_downloader_exception() 
 
     with pytest.raises(RuntimeError, match="failed during crawl"):
         scrapy_client._raise_for_crawl_errors(stats)
-
-
-class _PlaywrightLikeError(Exception):
-    pass
-
-
-_PlaywrightLikeError.__module__ = "playwright._impl._errors"
-
-
-def test_is_retryable_playwright_navigation_error_accepts_http2_protocol_error() -> None:
-    error = _PlaywrightLikeError("Page.goto: net::ERR_HTTP2_PROTOCOL_ERROR at https://example.com")
-
-    assert scrapy_client._is_retryable_playwright_navigation_error(error) is True
-
-
-def test_is_retryable_playwright_navigation_error_rejects_non_playwright_errors() -> None:
-    error = RuntimeError("Page.goto: net::ERR_HTTP2_PROTOCOL_ERROR at https://example.com")
-
-    assert scrapy_client._is_retryable_playwright_navigation_error(error) is False
-
-
-def test_is_retryable_playwright_navigation_error_rejects_other_playwright_errors() -> None:
-    error = _PlaywrightLikeError("Page.goto: net::ERR_ABORTED at https://example.com")
-
-    assert scrapy_client._is_retryable_playwright_navigation_error(error) is False

--- a/tests/dags/dag_mailbox_cleaner/test_config_validation.py
+++ b/tests/dags/dag_mailbox_cleaner/test_config_validation.py
@@ -78,3 +78,27 @@ def test_validate_config_rejects_archive_action_type(monkeypatch) -> None:
 
     assert valid is False
     assert "Invalid value for config.action.type" in msg
+
+
+def test_validate_config_accepts_safety_sort_asc(monkeypatch) -> None:
+    monkeypatch.setattr(validation, "_validate_airflow_imap_config", lambda _: (True, "OK"))
+
+    config = _base_config()
+    config["safety"]["sort"] = "asc"
+
+    valid, msg = validation.validate_config(config)
+
+    assert valid is True
+    assert msg == "OK"
+
+
+def test_validate_config_rejects_invalid_safety_sort(monkeypatch) -> None:
+    monkeypatch.setattr(validation, "_validate_airflow_imap_config", lambda _: (True, "OK"))
+
+    config = _base_config()
+    config["safety"]["sort"] = "middle"
+
+    valid, msg = validation.validate_config(config)
+
+    assert valid is False
+    assert "Invalid value for config.safety.sort" in msg

--- a/tests/dags/dag_mailbox_cleaner/test_process_mailbox_cleaner.py
+++ b/tests/dags/dag_mailbox_cleaner/test_process_mailbox_cleaner.py
@@ -25,6 +25,7 @@ class _FakeImapClient:
         self.moved_uids: list[tuple[bytes, str]] = []
         self.deleted_uids: list[bytes] = []
         self.expunge_called = False
+        self.search_uids_calls: list[dict[str, object]] = []
 
     def __enter__(self) -> "_FakeImapClient":
         return self
@@ -37,9 +38,13 @@ class _FakeImapClient:
         self.mailbox = mailbox
 
     def search_uids(self, criteria: str = "ALL", max_results: int | None = None, newest_first: bool = True) -> list[bytes]:
-        _ = criteria
-        _ = max_results
-        _ = newest_first
+        self.search_uids_calls.append(
+            {
+                "criteria": criteria,
+                "max_results": max_results,
+                "newest_first": newest_first,
+            }
+        )
         return [b"101"]
 
     def fetch_message(self, uid: bytes) -> ImapFetchedMessage:
@@ -130,3 +135,25 @@ def test_process_mailbox_cleaner_delete_executes_write(monkeypatch) -> None:
     fake_client = created["client"]
     assert fake_client.deleted_uids == [b"101"]
     assert fake_client.expunge_called is True
+
+
+def test_process_mailbox_cleaner_uses_desc_sort_by_default(monkeypatch) -> None:
+    monkeypatch.setattr(BaseHook, "get_connection", lambda *_args, **_kwargs: _FakeConnection())
+    created = _patch_fake_imap_client(monkeypatch)
+
+    process_module.process_mailbox_cleaner(config=_config(dry_run=True))
+
+    fake_client = created["client"]
+    assert fake_client.search_uids_calls[0]["newest_first"] is True
+
+
+def test_process_mailbox_cleaner_uses_asc_sort_when_configured(monkeypatch) -> None:
+    monkeypatch.setattr(BaseHook, "get_connection", lambda *_args, **_kwargs: _FakeConnection())
+    created = _patch_fake_imap_client(monkeypatch)
+    config = _config(dry_run=True)
+    config["safety"]["sort"] = "asc"
+
+    process_module.process_mailbox_cleaner(config=config)
+
+    fake_client = created["client"]
+    assert fake_client.search_uids_calls[0]["newest_first"] is False


### PR DESCRIPTION
- Introduced `safety.sort` parameter to control candidate processing order.
- Updated configuration validation to accept `asc` and `desc` values.
- Modified mailbox cleaner logic to respect sorting configuration.
- Enhanced tests to validate sorting behavior in configuration.